### PR TITLE
Comment bloodbath: cut every non-essential comment and docstring

### DIFF
--- a/Demo/AppDelegate.swift
+++ b/Demo/AppDelegate.swift
@@ -5,10 +5,9 @@ import Pinwheel
 @main
 struct DemoApp: App {
     init() {
-        // UI tests launch with `-UITesting`: start from a clean slate so a prior
-        // run's persisted catalog selection/device can't leak in, and disable
-        // animations so presentations don't slow down or flake the tests. The
-        // `-PinwheelPreview` arg lives in the argument domain, so it survives.
+        // -UITesting clears persisted state so a prior run's selection can't leak
+        // in, and disables animations so presentations don't flake the tests.
+        // -PinwheelPreview lives in the argument domain, so it survives the clear.
         if ProcessInfo.processInfo.arguments.contains("-UITesting") {
             if let domain = Bundle.main.bundleIdentifier {
                 UserDefaults.standard.removePersistentDomain(forName: domain)

--- a/Demo/Examples/DemoStateFixtures.swift
+++ b/Demo/Examples/DemoStateFixtures.swift
@@ -1,10 +1,7 @@
 import Pinwheel
 
-/// Shared copy for the loading / empty / failed example states, so the SwiftUI
-/// and UIKit parity examples stay in lockstep. The three state enums (`PinState`,
-/// `UIKitPinStateViewState`, `UIKitPinTableViewState`) are distinct types, so the
-/// strings are the shared piece; convenience `PinState` values are provided for
-/// the SwiftUI examples. Demo-only — not part of the package.
+// The three state enums are distinct types, so shared strings are what keep the
+// SwiftUI and UIKit parity examples in lockstep.
 enum DemoStateFixture {
     static let loadingTitle = "Loading..."
     static let loadingSubtitle = "Please wait while we fetch your details."

--- a/Demo/Examples/SwiftUI/DemoPinwheelSections.swift
+++ b/Demo/Examples/SwiftUI/DemoPinwheelSections.swift
@@ -43,11 +43,8 @@ enum DemoPinwheelSections {
 }
 
 #if DEBUG
-/// Fast visual iteration on any catalog component, no throwaway `#Preview`
-/// needed: change `previewComponentID` to any id below and render this preview.
-/// Ids are bare (`"swiftui-button"`) or qualified (`"components/swiftui-button"`);
-/// an unknown id renders a list of every available id. For a running simulator
-/// instead, deep-link the Demo: `simctl launch <bundle> -PinwheelPreview swiftui-button`.
+// Change to any catalog id and render the preview below; an unknown id renders a
+// list of every available id.
 private let previewComponentID = Catalog.fullscreenView.id(.uiKit)
 
 #Preview("Pinwheel Component") {

--- a/Demo/Examples/SwiftUI/TokensSwiftUIExamples.swift
+++ b/Demo/Examples/SwiftUI/TokensSwiftUIExamples.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import Pinwheel
 
 struct PinFontExample: SwiftUI.View {
-    // The themed typography surface (provider-backed), mirroring UIKitPinFontExample.
     private let styles: [(String, PinTextStyle)] = [
         ("Title", .title),
         ("Subtitle", .subtitle),

--- a/Demo/Examples/UIKit/UIKitPinDataSourceTableViewExample.swift
+++ b/Demo/Examples/UIKit/UIKitPinDataSourceTableViewExample.swift
@@ -1,8 +1,6 @@
 import UIKit
 import Pinwheel
 
-/// Demos the data-source path (`init(dataSource:)`) — the dynamic-content
-/// counterpart to the static-array `UIKitPinTableViewExample`.
 class UIKitPinDataSourceTableViewExample: UIKitPinView, Tweakable {
     private var rowCount = 6
 

--- a/Demo/Examples/UIKit/UIKitPinTableViewExample.swift
+++ b/Demo/Examples/UIKit/UIKitPinTableViewExample.swift
@@ -20,8 +20,6 @@ class UIKitPinTableViewExample: UIKitPinView, Tweakable {
     }()
 
     lazy var tableView: UIKitPinTableView = {
-        // Shadow on, so this demos `ShadowScrollView`/`ShadowView` — the top
-        // scroll-edge shadow that deepens as rows pass under the top edge.
         let view = UIKitPinTableView(items: items, usingShadowWhenScrolling: true)
         view.delegate = self
         return view
@@ -48,9 +46,6 @@ class UIKitPinTableViewExample: UIKitPinView, Tweakable {
         let on = UIKitPinBoolTableViewItem(title: "On")
         on.isOn = true
 
-        // The variant rows above are the demo's focus; the filler rows below just
-        // make the list overflow the medium sheet so the scroll-edge shadow shows
-        // when you drag (it never appears if the content fits without scrolling).
         let variants: [UIKitPinTableViewItem] = [
             onlyTitle,
             titleAndSubtitle,
@@ -61,6 +56,8 @@ class UIKitPinTableViewExample: UIKitPinView, Tweakable {
             off,
             on
         ]
+        // Filler rows make the list overflow the sheet; the scroll-edge shadow
+        // only shows once content scrolls.
         let filler = (1...12).map { UIKitPinTextTableViewItem(title: "Row \($0)") }
         return variants + filler
     }()

--- a/Demo/Examples/UIKit/UIKitPinViewControllerExample.swift
+++ b/Demo/Examples/UIKit/UIKitPinViewControllerExample.swift
@@ -1,9 +1,6 @@
 import UIKit
 import Pinwheel
 
-/// Demos the `PinwheelItem(_:viewController:)` seam by hosting a
-/// `UIKitPinStateView` inside a raw `UIViewController` — same state tweaks and
-/// retry reaction as the `view:`-hosted `UIKitPinStateViewExample`.
 class UIKitPinViewControllerExample: UIViewController, Tweakable {
     lazy var tweaks: [Tweak] = {
         return [

--- a/DemoCatalog/Sources/DemoCatalog/Catalog.swift
+++ b/DemoCatalog/Sources/DemoCatalog/Catalog.swift
@@ -1,9 +1,7 @@
 @_exported import Pinwheel
 
-/// The demo catalog's component names — the single source of truth for titles,
-/// shared by the Demo app (which builds the catalog) and DemoUITests (which
-/// deep-links to a component). Re-exports Pinwheel so importing `DemoCatalog` is
-/// all either target needs (`PinTag`, `PinwheelItem`, … come along).
+// A shared module because a UI-test target can't import the app, yet both the
+// Demo and DemoUITests need these component names to agree.
 public enum Catalog: String, PinwheelComponent {
     case font = "Font"
     case color = "Color"

--- a/DemoUITests/StateViewUITests.swift
+++ b/DemoUITests/StateViewUITests.swift
@@ -1,24 +1,16 @@
 import XCTest
 import DemoCatalog
 
-/// Exercises the StateView through the deep-link preview (`-PinwheelPreview <id>`),
-/// covering interactions that screenshots can't verify headlessly: opening the
-/// playground settings, switching to the failed state via a tweak, and tapping
-/// the failed-state action ("Retry").
 final class StateViewUITests: XCTestCase {
     private var app: XCUIApplication!
 
-    /// Failure ceiling for element waits — `waitForExistence` returns as soon as
-    /// the element appears, so this only bounds how long a *failing* test waits.
-    /// 5s is the community default; this suite is local, animation-free and
-    /// network-free, so elements appear well within it.
+    // Only bounds how long a failing test waits — waitForExistence returns as
+    // soon as the element appears.
     private let defaultTimeout: TimeInterval = 5
 
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        // -UITesting makes the app clear persisted catalog state and disable
-        // animations on launch (see DemoApp); tests add -PinwheelPreview as needed.
         app.launchArguments = ["-UITesting"]
     }
 
@@ -31,8 +23,6 @@ final class StateViewUITests: XCTestCase {
         app.launch()
     }
 
-    /// Opens the playground settings and selects the "Failed" tweak, leaving the
-    /// component in its failed state with the action button visible.
     private func selectFailedState() {
         let settings = app.buttons["pinwheel.settings"]
         XCTAssertTrue(settings.waitForExistence(timeout: defaultTimeout), "settings (wrench) button should exist")
@@ -42,8 +32,6 @@ final class StateViewUITests: XCTestCase {
         XCTAssertTrue(failed.waitForExistence(timeout: defaultTimeout), "Failed tweak should be listed in the settings sheet")
         failed.tap()
     }
-
-    // MARK: - SwiftUI PinStateView
 
     @MainActor
     func testSwiftUIStateViewRendersDefaultEmptyState() {
@@ -65,8 +53,6 @@ final class StateViewUITests: XCTestCase {
                       "Tapping Retry should switch the SwiftUI state view to loading")
     }
 
-    // MARK: - UIKit shell (UIKitPinStateView over PinStateView)
-
     @MainActor
     func testUIKitStateViewBridgesTweaksAndRetry() {
         launchPreview(.stateView, .uiKit)
@@ -81,12 +67,6 @@ final class StateViewUITests: XCTestCase {
                       "Tapping Retry should fire the delegate and switch the UIKit state view to loading")
     }
 
-    // MARK: - UIKit view-controller host (UIKitPinStateView inside a UIViewController)
-
-    /// Same contract as the `view:`-hosted case above, but through the
-    /// `PinwheelItem(viewController:)` path — guards that a `UIViewController`'s
-    /// `Tweakable` tweaks bridge into the settings sheet and that the retry tap
-    /// drives the live (on-screen) instance, not an off-screen copy.
     @MainActor
     func testUIKitViewControllerStateViewBridgesTweaksAndRetry() {
         launchPreview(.viewController, .uiKit)

--- a/DemoUITests/TweakableUITests.swift
+++ b/DemoUITests/TweakableUITests.swift
@@ -1,24 +1,16 @@
 import XCTest
 import DemoCatalog
 
-/// Exercises the Tweakable examples through the deep-link preview
-/// (`-PinwheelPreview <id>`): opening the playground settings and choosing an
-/// option should mutate the example's content. Covers both the SwiftUI
-/// `pinwheelTweaks` path and the UIKit `Tweakable` → `PinwheelTweak` bridge.
 final class TweakableUITests: XCTestCase {
     private var app: XCUIApplication!
 
-    /// Failure ceiling for element waits — `waitForExistence` returns as soon as
-    /// the element appears, so this only bounds how long a *failing* test waits.
-    /// 5s is the community default; this suite is local, animation-free and
-    /// network-free, so elements appear well within it.
+    // Only bounds how long a failing test waits — waitForExistence returns as
+    // soon as the element appears.
     private let defaultTimeout: TimeInterval = 5
 
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        // -UITesting makes the app clear persisted catalog state and disable
-        // animations on launch (see DemoApp); tests add -PinwheelPreview as needed.
         app.launchArguments = ["-UITesting"]
     }
 
@@ -37,13 +29,11 @@ final class TweakableUITests: XCTestCase {
         settings.tap()
     }
 
-    /// Navigates the real catalog to `component` in `section`, switching sections
-    /// via the picker only when the item isn't already on screen. Items match by
-    /// stable id (`component.id(tag)`), not title: with world (SwiftUI/UIKit) now a
-    /// tag, two rows in a section can share a title (e.g. both "Tweakable").
+    // Matches items by stable id, not title: with world (SwiftUI/UIKit) now a
+    // tag, two rows in a section can share a title (e.g. both "Tweakable").
     private func openCatalogItem(_ component: Catalog, _ tag: PinTag, in section: CatalogSection) {
         // -UITesting resets state, so the catalog always launches to the list —
-        // there's no restored item to dismiss first.
+        // no restored item to dismiss first.
         XCTAssertTrue(app.buttons["pinwheel.sectionPicker"].waitForExistence(timeout: defaultTimeout),
                       "section picker should exist")
 
@@ -58,8 +48,6 @@ final class TweakableUITests: XCTestCase {
         }
         item.tap()
     }
-
-    // MARK: - SwiftUI pinwheelTweaks
 
     @MainActor
     func testSwiftUIActionTweakUpdatesContent() {
@@ -82,10 +70,9 @@ final class TweakableUITests: XCTestCase {
         let option3 = app.switches["Option 3, Toggle-backed option"]
         XCTAssertTrue(option3.waitForExistence(timeout: defaultTimeout), "Option 3 toggle should be listed")
         // The row is a single combined element; tapping its center hits the label,
-        // so tap the switch control on the trailing edge to actually flip it.
+        // so tap the trailing edge to flip the switch control itself.
         option3.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5)).tap()
 
-        // The label updates behind the sheet (no Done button to dismiss anymore).
         XCTAssertTrue(app.staticTexts["Option 3 is on"].waitForExistence(timeout: defaultTimeout),
                       "Toggling a bool tweak should update the example label")
     }
@@ -101,16 +88,13 @@ final class TweakableUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Chosen Option 1"].waitForExistence(timeout: defaultTimeout))
 
         openSettings()
-        // The row carries a description, so its accessibility label is the
-        // combined "title, description".
+        // A described row's accessibility label is the combined "title, description".
         let option2 = app.buttons["Option 2, Description 2"]
         XCTAssertTrue(option2.waitForExistence(timeout: defaultTimeout), "Option 2 should still be listed on reopen")
         option2.tap()
         XCTAssertTrue(app.staticTexts["Chosen Option 2"].waitForExistence(timeout: defaultTimeout),
                       "A second tweak selection should still update the example label")
     }
-
-    // MARK: - Catalog navigation (the real user path: nested presentation)
 
     @MainActor
     func testCatalogTweakableActionUpdatesContent() {
@@ -127,8 +111,6 @@ final class TweakableUITests: XCTestCase {
                       "Choosing a tweak from the catalog (nested presentation) should update the label")
     }
 
-    // MARK: - UIKit Tweakable bridge
-
     @MainActor
     func testCatalogUIKitTweakableActionUpdatesContent() {
         app.launch()
@@ -144,8 +126,6 @@ final class TweakableUITests: XCTestCase {
                       "A UIKit tweak chosen from the catalog should update the hosted view's label")
     }
 
-    // MARK: - Device selection (repro)
-
     @MainActor
     func testSelectingSimulatedDeviceDoesNotCrash() {
         launchPreview(.tweakable, .swiftUI)
@@ -159,11 +139,9 @@ final class TweakableUITests: XCTestCase {
         XCTAssertTrue(device.waitForExistence(timeout: defaultTimeout), "iPhone XS/11 Pro should be listed")
         device.tap()
 
-        // Selecting a simulated device used to overflow SwiftUI's layout engine
-        // and crash the app (the resize was implicitly animated). Selecting does
-        // not dismiss the settings sheet, so the device list stays on screen —
-        // re-querying another row proves the app survived and stayed responsive
-        // (a crashed/hung app fails this query rather than returning at once).
+        // Selecting a simulated device used to crash the app (an implicitly
+        // animated resize overflowed SwiftUI's layout engine). Re-querying another
+        // row proves the app survived, since a crashed/hung app fails this query.
         XCTAssertTrue(app.buttons["iPhone SE (2nd & 3rd generation)"].waitForExistence(timeout: defaultTimeout),
                       "device list should stay responsive after selecting a device")
     }

--- a/Pinwheel/Sources/Pinwheel/API/Pinwheel.swift
+++ b/Pinwheel/Sources/Pinwheel/API/Pinwheel.swift
@@ -7,16 +7,14 @@ public enum TabletDisplayMode {
     case fullscreen
 }
 
-/// How a catalog item is presented when opened.
 public enum PinwheelPresentation {
     case medium
     case large
     case fullscreen
 }
 
-/// Orthogonal labels a catalog item carries for browsing/filtering — the world
-/// an example lives in, so SwiftUI/UIKit is a tag on a concept-grouped item
-/// rather than its own section. `rawValue` is the chip text.
+/// A world tag on a concept-grouped item, so SwiftUI/UIKit is a filter rather
+/// than its own section. `rawValue` is the chip text.
 public enum PinTag: String, Hashable, Sendable {
     case swiftUI = "SwiftUI"
     case uiKit = "UIKit"
@@ -72,8 +70,7 @@ public struct PinwheelSection {
     public let title: String
     public let items: [PinwheelItem]
 
-    /// Stable identity for persistence — the title slugified. Section titles are
-    /// unique within a catalog.
+    /// Slugified title; must be unique within a catalog since persistence keys off it.
     public var id: String {
         title.pinwheelGeneratedID
     }
@@ -101,16 +98,14 @@ public struct PinwheelItem {
     public let tags: [PinTag]
     private let makeSwiftUIView: () -> AnyView
 
-    /// Stable identity for persistence and deep-links: the title slugified and
-    /// prefixed by any tags, so same-titled items in different worlds (SwiftUI
-    /// "Font" vs UIKit "Font") get distinct ids. Title + tags must be unique
-    /// within a section.
+    /// Slugified title prefixed by tags, so same-titled items in different worlds
+    /// (SwiftUI "Font" vs UIKit "Font") get distinct ids. Title + tags must be
+    /// unique within a section.
     public var id: String {
         PinwheelItem.generatedID(title: title, tags: tags)
     }
 
-    /// The id an item with this `title` and `tags` resolves to — lets callers
-    /// form a deep-link (`-PinwheelPreview <id>`) without hardcoding the slug.
+    /// Lets callers form a deep-link (`-PinwheelPreview <id>`) without hardcoding the slug.
     nonisolated public static func generatedID(title: String, tags: [PinTag] = []) -> String {
         return (tags.map(\.rawValue) + [title]).joined(separator: " ").pinwheelGeneratedID
     }
@@ -161,8 +156,6 @@ public struct PinwheelItem {
         _ title: String,
         view: ViewType.Type
     ) {
-        // Shared by the `makeSwiftUIView` closure below so the hosted view is
-        // created once and reused (see the note at its use site).
         var sharedHostedView: ViewType?
         self.init(
             title: title,
@@ -172,12 +165,9 @@ public struct PinwheelItem {
             constrainToBottomSafeArea: true,
             tabletDisplayMode: .fullscreen,
             makeSwiftUIView: {
-                // Build the hosted view once and reuse it across playground
-                // re-renders. The bridged tweak closures capture this instance,
-                // and `PinwheelUIKitViewController` hosts the same one — a fresh
-                // `ViewType` per call would leave the tweaks mutating an
-                // off-screen instance, so UIKit tweaks appeared to do nothing
-                // (the displayed label never changed) under nested presentation.
+                // Reuse one instance across re-renders: the tweak closures capture
+                // it, so a fresh view per call would leave tweaks mutating an
+                // off-screen copy (they'd silently no-op).
                 let view = sharedHostedView ?? {
                     let created = ViewType(frame: .zero)
                     sharedHostedView = created
@@ -215,10 +205,9 @@ public struct PinwheelItem {
         _ title: String,
         viewController: @escaping () -> UIViewController
     ) {
-        // Build the hosted controller once and reuse it across playground
-        // re-renders, mirroring the `view:` initializer: the bridged tweak
-        // closures capture this instance, so a fresh controller per render would
-        // leave them mutating an off-screen copy (tweaks silently no-op).
+        // Reuse one instance across re-renders: the tweak closures capture it, so
+        // a fresh controller per call would leave tweaks mutating an off-screen
+        // copy (they'd silently no-op).
         var sharedViewController: UIViewController?
         self.init(
             title: title,
@@ -369,7 +358,7 @@ enum PinwheelStateStore {
     private static let selectedSectionIDKey = "Pinwheel.SelectedSectionID"
     private static let selectedItemIDKey = "Pinwheel.SelectedItemID"
     private static let selectedDeviceBySelectionKey = "Pinwheel.SelectedDeviceBySelection"
-    // Legacy key retained so the persisted FAB corner survives this consolidation.
+    // Legacy key retained so the persisted FAB corner survives.
     private static let floatingControlsCornerKey = "lastCornerForTweakingButtonKey"
 
     static var selectedSectionID: String? {
@@ -386,7 +375,6 @@ enum PinwheelStateStore {
         UserDefaults.standard.removeObject(forKey: selectedItemIDKey)
     }
 
-    /// Index of the screen corner the floating controls last settled in.
     static var floatingControlsCorner: Int? {
         get { UserDefaults.standard.object(forKey: floatingControlsCornerKey) as? Int }
         set {

--- a/Pinwheel/Sources/Pinwheel/API/PinwheelComponent.swift
+++ b/Pinwheel/Sources/Pinwheel/API/PinwheelComponent.swift
@@ -1,19 +1,14 @@
 import SwiftUI
 import UIKit
 
-/// A consumer's catalog component name: a `String`-backed enum whose `rawValue`
-/// is the display title. Conforming gives typed `PinwheelItem` creation
-/// (`PinwheelItem(MyComponent.button)`) and a deep-link `id(_:)` — the same id
-/// the built item resolves to — so previews and UI tests reference components
-/// without a hardcoded slug string. Define it in a module your app *and* its
-/// UI-test target import (a UI-test target runs in a separate process and can't
-/// `@testable import` the app), and both sides stay in sync from one source.
+/// A `String`-backed enum whose `rawValue` is the display title. Define it in a
+/// module both the app *and* its UI-test target import: a UI-test target runs in
+/// a separate process and can't `@testable import` the app, so a shared module is
+/// the only way both sides resolve the same ids.
 public protocol PinwheelComponent: RawRepresentable where RawValue == String {}
 
 public extension PinwheelComponent {
-    /// The deep-link id this component resolves to under `tags` — matches the
-    /// id of the `PinwheelItem` built from it, so `-PinwheelPreview <id>` needs
-    /// no hardcoded slug. `Catalog.stateView.id(.uiKit) == "uikit-stateview"`.
+    /// Matches the id of the `PinwheelItem` built from this name. `Catalog.stateView.id(.uiKit) == "uikit-stateview"`.
     nonisolated func id(_ tags: PinTag...) -> String {
         return PinwheelItem.generatedID(title: rawValue, tags: tags)
     }

--- a/Pinwheel/Sources/Pinwheel/API/PinwheelTweak.swift
+++ b/Pinwheel/Sources/Pinwheel/API/PinwheelTweak.swift
@@ -52,8 +52,7 @@ public struct PinwheelTweak: Identifiable, Equatable {
         return lhs.id == rhs.id && lhs.title == rhs.title && lhs.description == rhs.description
     }
 
-    /// Applies this tweak as a preview "variant": runs an action tweak, or turns
-    /// a toggle on. Used by the deep-link preview to land on a specific variant.
+    /// Lands the deep-link preview on this variant: runs an action, or forces a toggle on (never off).
     func applyAsPreviewVariant() {
         switch control {
         case .action(let action):

--- a/Pinwheel/Sources/Pinwheel/Bridge/PinwheelHostView.swift
+++ b/Pinwheel/Sources/Pinwheel/Bridge/PinwheelHostView.swift
@@ -1,13 +1,9 @@
 import SwiftUI
 import UIKit
 
-/// Hosts a SwiftUI `Pin*` component as a self-sizing `UIView`, so SwiftUI-first
-/// components can be dropped into a UIKit `UIStackView` / Auto Layout hierarchy
-/// from a hybrid app — no SwiftUI knowledge required at the call site.
-///
-/// The hosting controller is re-parented to the nearest view controller when the
-/// view moves to a window, so safe-area, trait (light/dark, Dynamic Type) and
-/// environment propagation behave correctly.
+/// Hosts a SwiftUI `Pin*` component as a self-sizing `UIView` for UIKit call sites.
+/// The hosting controller is re-parented to the nearest view controller on window
+/// move, so safe-area, trait, and environment propagation work.
 public final class PinHostView<Content: SwiftUI.View>: UIView {
     private let hostingController: UIHostingController<Content>
 
@@ -18,8 +14,8 @@ public final class PinHostView<Content: SwiftUI.View>: UIView {
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .clear
 
-        // Publishes SwiftUI's ideal size as the hosting view's intrinsic content
-        // size, so the host hugs its content inside stack views / Auto Layout.
+        // Publish SwiftUI's ideal size as intrinsic content size so the host hugs
+        // its content inside stack views / Auto Layout.
         hostingController.sizingOptions = .intrinsicContentSize
         hostingController.view.backgroundColor = .clear
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -41,7 +37,6 @@ public final class PinHostView<Content: SwiftUI.View>: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// The hosted SwiftUI view. Reassign to re-render with new state.
     public var rootView: Content {
         get { hostingController.rootView }
         set { hostingController.rootView = newValue }

--- a/Pinwheel/Sources/Pinwheel/Bridge/PinwheelUIKitCompatibility.swift
+++ b/Pinwheel/Sources/Pinwheel/Bridge/PinwheelUIKitCompatibility.swift
@@ -17,9 +17,7 @@ public struct PinwheelUIKitViewController: UIViewControllerRepresentable {
 }
 
 extension PinwheelTweak {
-    /// Bridges a UIKit `Tweak` to a SwiftUI `PinwheelTweak`, so a hosted
-    /// `Tweakable` UIKit view's options appear in the SwiftUI playground's
-    /// settings sheet. Returns nil for unknown `Tweak` kinds.
+    /// Returns nil for unknown `Tweak` kinds.
     init?(_ tweak: Tweak) {
         if let text = tweak as? TextTweak {
             self.init(text.title, description: text.description, action: text.action)
@@ -31,8 +29,6 @@ extension PinwheelTweak {
     }
 }
 
-/// Backs a bridged `BoolTweak` with mutable state and forwards changes to the
-/// UIKit tweak's action.
 private final class PinwheelTweakBoolStore {
     private var isOn: Bool
     private let action: (Bool) -> Void
@@ -53,14 +49,10 @@ private final class PinwheelTweakBoolStore {
     }
 }
 
-/// Hosts a UIKit view as a view controller's full-bounds content.
-///
-/// Used to embed `view:` catalog items in SwiftUI: a `UIViewControllerRepresentable`
-/// is handed the full proposed size by SwiftUI, so the hosted view lays out at
-/// full bounds — as it would in a real UIKit hierarchy. A bare
-/// `UIViewRepresentable` instead sizes to the view's fitting size, which left
-/// edge-pinned UIKit examples (e.g. the Tokens examples, table-backed examples)
-/// collapsed to content and pinned top-left in the catalog/preview.
+/// Hosts a UIKit view at full bounds. Wrapping in a `UIViewControllerRepresentable`
+/// (not a bare `UIViewRepresentable`) is deliberate: SwiftUI hands a controller the
+/// full proposed size, whereas a `UIViewRepresentable` sizes to the fitting size and
+/// collapses edge-pinned examples (Tokens, table-backed) to the top-left.
 final class PinwheelUIKitContainerViewController: UIViewController {
     private let makeContent: () -> UIView
 

--- a/Pinwheel/Sources/Pinwheel/Catalog/Device.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/Device.swift
@@ -27,7 +27,6 @@ struct Device {
         return frame.width <= currentSize.width && frame.height <= currentSize.height
     }
 
-    /// The device matching the real screen — the default ("no simulation") target.
     var isCurrent: Bool {
         return traits.userInterfaceIdiom == .phone && frame.size == UIScreen.main.bounds.size
     }

--- a/Pinwheel/Sources/Pinwheel/Catalog/FloatingControls/CornerAnchoringView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/FloatingControls/CornerAnchoringView.swift
@@ -73,7 +73,6 @@ final class CornerAnchoringView: UIView {
         }
     }
 
-    /// Shows/hides the controls with a quick fade + shrink toward their corner.
     func setControlsHidden(_ hidden: Bool, animated: Bool, completion: (() -> Void)? = nil) {
         let apply = {
             self.buttonsView.alpha = hidden ? 0 : 1
@@ -160,12 +159,10 @@ final class CornerAnchoringView: UIView {
         setupKeyboardNotifications()
     }
 
-    /// Keeps the FAB above the keyboard. The controls live in a pass-through
-    /// overlay window above the app (and above any sheet), so nothing else moves
-    /// them clear of the keyboard. Each bottom corner holds two bottom
-    /// constraints — one to the safe area, one to `keyboardLayoutGuide.topAnchor`
-    /// — and these notifications swap between them so the settings/close buttons
-    /// stay tappable on keyboard-bearing screens (e.g. the fullscreen editor).
+    /// The FAB lives in an overlay window above the app, so nothing else moves it
+    /// clear of the keyboard. These notifications swap each bottom corner between
+    /// its safe-area and `keyboardLayoutGuide.topAnchor` constraints so the
+    /// buttons stay tappable on keyboard-bearing screens.
     private func setupKeyboardNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
@@ -273,7 +270,6 @@ final class CornerAnchoringView: UIView {
         return (initialVelocity / 1000) * decelerationRate / (1 - decelerationRate)
     }
 
-    /// Finds the position of the nearest corner to the given point.
     private func nearestCorner(to point: CGPoint) -> (Int, CGPoint) {
         var minDistance = CGFloat.greatestFiniteMagnitude
         var closestPosition = CGPoint.zero
@@ -289,13 +285,11 @@ final class CornerAnchoringView: UIView {
         return (arrayIndex, closestPosition)
     }
 
-    /// Calculates the relative velocity needed for the initial velocity of the animation.
     private func relativeVelocity(forVelocity velocity: CGFloat, from currentValue: CGFloat, to targetValue: CGFloat) -> CGFloat {
         guard currentValue - targetValue != 0 else { return 0 }
         return velocity / (targetValue - currentValue)
     }
 
-    /// Forwards all touches not applied to subviews.
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         return subviews.contains(where: {
             !$0.isHidden && $0.point(inside: self.convert(point, to: $0), with: event)
@@ -313,12 +307,7 @@ final class CornerAnchoringView: UIView {
 
 extension UISpringTimingParameters {
 
-    /// A design-friendly way to create a spring timing curve.
-    ///
-    /// - Parameters:
-    ///   - damping: The 'bounciness' of the animation. Value must be between 0 and 1.
-    ///   - response: The 'speed' of the animation.
-    ///   - initialVelocity: The vector describing the starting motion of the property. Optional, default is `.zero`.
+    /// `damping` must be between 0 and 1.
     convenience init(damping: CGFloat, response: CGFloat, initialVelocity: CGVector = .zero) {
         let stiffness = pow(2 * .pi / response, 2)
         let damp = 4 * .pi * damping / response
@@ -329,8 +318,6 @@ extension UISpringTimingParameters {
 
 extension CGPoint {
 
-    /// Calculates the distance between two points in 2D space.
-    /// + returns: The distance from this point to the given point.
     func distance(to point: CGPoint) -> CGFloat {
         return sqrt(pow(point.x - self.x, 2) + pow(point.y - self.y, 2))
     }

--- a/Pinwheel/Sources/Pinwheel/Catalog/FloatingControls/FloatingButton+Style.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/FloatingControls/FloatingButton+Style.swift
@@ -17,7 +17,6 @@ extension FloatingButton {
     }
 }
 
-// MARK: - Styles
 extension FloatingButton.Style {
     static var `default`: FloatingButton.Style {
         FloatingButton.Style(

--- a/Pinwheel/Sources/Pinwheel/Catalog/FloatingControls/FloatingButton.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/FloatingControls/FloatingButton.swift
@@ -28,7 +28,6 @@ final class FloatingButton: UIButton {
         return label
     }()
 
-    // MARK: - Init
     override convenience init(frame: CGRect) {
         self.init(frame: frame, style: .default)
     }
@@ -42,8 +41,6 @@ final class FloatingButton: UIButton {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    // MARK: - Setup
 
     override func layoutSubviews() {
         super.layoutSubviews()

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -283,8 +283,6 @@ private struct PinwheelIndexView: SwiftUI.View {
         .buttonStyle(.plain)
     }
 
-    /// Distinct tags across the section's items, in first-appearance order — the
-    /// filter offers "All" plus one pill per tag actually present.
     private var sectionTags: [PinTag] {
         guard let section else { return [] }
         var ordered: [PinTag] = []

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelChrome.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelChrome.swift
@@ -1,42 +1,23 @@
 import SwiftUI
 
-/// The seam between the SwiftUI catalog/preview and the floating tweak/close
-/// controls (a UIKit `CornerAnchoringView` hosted in a pass-through overlay
-/// window — see `PinwheelFloatingControlsHost`).
-///
-/// The controls live in a separate `UIWindow` so they float *above* sheet
-/// presentations and never clip to (or clash with) the presented content. The
-/// SwiftUI side only reads/writes this coordinator; the window observes it.
 @MainActor
 @Observable
 final class PinwheelChrome {
-    /// The presented component's tweaks. Held here (a persistent reference) rather
-    /// than in the playground's `@State` so they survive playground re-renders /
-    /// identity changes — the deep-link preview otherwise lost them when the
-    /// settings sheet opened, leaving the sheet empty.
+    /// Held here rather than in the playground's `@State` so they survive
+    /// playground re-renders / identity changes — the deep-link preview otherwise
+    /// lost them when the settings sheet opened, leaving the sheet empty.
     var tweaks: [PinwheelTweak] = []
-    /// Whether a component is currently presented — gates the FAB's visibility.
     var isPresentingItem: Bool = false
-    /// Drives the SwiftUI settings sheet; the wrench button sets this `true`.
     var showsSettings: Bool = false
-    /// The simulated device index into `Device.all`, or nil for the real device.
-    /// Held here so the settings sheet, the playground resize, and the floating
-    /// device pill share one source of truth.
     var selectedDeviceIndex: Int?
-    /// Dismisses the presented component; the close button invokes this.
     var onClose: (() -> Void)?
 
-    /// Badge count shown on the tweak (wrench) button.
     var tweakCount: Int { tweaks.count }
 
-    /// The FAB shows only while a component is presented and the settings sheet
-    /// is closed (so it never floats over the settings sheet itself).
     var isFloatingControlsVisible: Bool {
         isPresentingItem && !showsSettings
     }
 
-    /// The simulated device — set, and not the real device. nil means "no
-    /// simulation" (real device), which the pill treats as nothing to show.
     var simulatedDevice: Device? {
         guard let selectedDeviceIndex, let device = Device.all[safe: selectedDeviceIndex], !device.isCurrent else {
             return nil
@@ -44,9 +25,6 @@ final class PinwheelChrome {
         return device
     }
 
-    /// The device pill shows whenever a non-current device is simulated — even
-    /// while the settings sheet is open (so you can see the active device while
-    /// picking) and after it's dismissed.
     var isDevicePillVisible: Bool {
         isPresentingItem && simulatedDevice != nil
     }

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFloatingControlsHost.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFloatingControlsHost.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 import UIKit
 
-/// Installs a pass-through overlay `UIWindow` hosting the UIKit `CornerAnchoringView`
-/// FAB, and pushes `PinwheelChrome` state into it. Placed as a background of the
-/// catalog/preview root; touches outside the FAB buttons fall through to the app
-/// below. (The device pill rides on the playground itself, not this window.)
 struct PinwheelFloatingControlsHost: UIViewRepresentable {
     let chrome: PinwheelChrome
     let tweakCount: Int
@@ -41,8 +37,6 @@ struct PinwheelFloatingControlsHost: UIViewRepresentable {
         coordinator.teardown()
     }
 
-    /// An invisible probe that reports when it enters a window scene, so the
-    /// overlay window can be created at exactly the right moment.
     final class ProbeView: UIView {
         var onMoveToScene: ((UIWindowScene) -> Void)?
 
@@ -74,9 +68,6 @@ struct PinwheelFloatingControlsHost: UIViewRepresentable {
 
             if fabVisible { window.isHidden = false }
 
-            // Animate the FAB (fade + shrink) only on a visibility change, then drop
-            // the window once the FAB is gone (the pill lives on the playground, so
-            // nothing else needs this window).
             if fabVisible != fabShown {
                 fabShown = fabVisible
                 window.controller.anchoringView.setControlsHidden(!fabVisible, animated: true) {
@@ -95,8 +86,6 @@ struct PinwheelFloatingControlsHost: UIViewRepresentable {
     }
 }
 
-/// A pass-through window: only the FAB buttons capture touches; everything else
-/// falls through to the app window below.
 final class PinwheelFloatingControlsWindow: UIWindow {
     let controller = PinwheelFloatingControlsViewController()
 
@@ -111,9 +100,8 @@ final class PinwheelFloatingControlsWindow: UIWindow {
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        // Pass through everywhere except the FAB buttons. Over empty areas
-        // `UIWindow.hitTest` returns the window itself (or the pass-through
-        // container); only deeper interactive views should capture the touch.
+        // Over empty areas `UIWindow.hitTest` returns the window itself (or the
+        // pass-through container); only deeper interactive views capture the touch.
         guard let hit = super.hitTest(point, with: event), hit !== self, hit !== controller.view else {
             return nil
         }
@@ -121,8 +109,6 @@ final class PinwheelFloatingControlsWindow: UIWindow {
     }
 }
 
-/// Hosts the UIKit `CornerAnchoringView` FAB and the SwiftUI device pill in the
-/// overlay window, forwarding the FAB button taps to the coordinator.
 final class PinwheelFloatingControlsViewController: UIViewController, CornerAnchoringViewDelegate {
     let anchoringView = CornerAnchoringView()
     var onSettings: (() -> Void)?
@@ -155,8 +141,6 @@ final class PinwheelFloatingControlsViewController: UIViewController, CornerAnch
     }
 }
 
-/// Forwards hit-testing to its subviews, so the surrounding overlay window is
-/// transparent to touches everywhere except the FAB buttons.
 final class PinwheelPassthroughView: UIView {
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         for subview in subviews where !subview.isHidden && subview.isUserInteractionEnabled && subview.alpha > 0.01 {

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPlayground.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPlayground.swift
@@ -5,11 +5,7 @@ struct PinwheelPlayground: SwiftUI.View {
     let selection: PinwheelSelection
     let onClose: () -> Void
 
-    /// Preview mode (deep-link). When set, the component's tweak titles are
-    /// dumped for tooling and `autoApplyTweak` is applied once it's available.
     var previewMode: Bool = false
-    /// Title of a tweak to auto-apply on launch, so the preview lands directly
-    /// on a variant (e.g. the StateView "Failed" state) without tapping.
     var autoApplyTweak: String?
 
     @SwiftUI.State private var didApplyPreviewTweak = false
@@ -21,30 +17,22 @@ struct PinwheelPlayground: SwiftUI.View {
         @Bindable var chrome = chrome
         return content
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            // Letterbox a simulated (smaller) device against the inverse-of-
-            // surface token so the resized frame is visible — near-black in
-            // light, light in dark — rather than blending into the content.
+            // Letterbox a simulated device against the inverse-of-surface token
+            // so the resized frame stays visible in light and dark.
             .background(
                 chrome.simulatedDevice != nil ? .primaryText : .primaryBackground
             )
-            // The frame resize is NOT implicitly animated: an
-            // `.animation(_:value: selectedDeviceIndex)` here animates the whole
-            // subtree — including the hosted item and the preference plumbing —
-            // and recursed SwiftUI's layout engine into a stack overflow that
-            // crashed the app on every device pick. The resize snaps instead.
-            // The device pill rides on top of the playground (not in the FAB's
-            // overlay window) so its shrink+fade is a plain SwiftUI transition —
-            // hosting it in the window collapsed its intrinsic frame on the way
-            // out instead of scaling in place.
+            // Don't animate the device-frame resize with `.animation(value:)`: it
+            // recurses SwiftUI's layout into a stack overflow (crashes on every
+            // device pick). The pill rides the playground, not the FAB window, so
+            // its transition scales in place instead of collapsing.
             .overlay(alignment: .top) {
                 PinwheelDevicePill()
                     .padding(.top, .spacingS)
             }
             .onAppear {
-                // Preview/deep-link renders stay isolated from interactive
-                // catalog persistence: always the host device (no restored
-                // simulation leaking a pill + letterbox into a snapshot), and
-                // no write-back below that would clobber a saved device pick.
+                // Preview renders skip device restore/persistence so a saved
+                // simulation can't leak into a snapshot or clobber a real pick.
                 if !previewMode {
                     chrome.selectedDeviceIndex = PinwheelStateStore.selectedDeviceIndex(for: selection)
                 }
@@ -77,10 +65,6 @@ struct PinwheelPlayground: SwiftUI.View {
 
     private var content: some SwiftUI.View {
         let device = selectedDevice
-        // A simulated device pins the content to its point size; the real device
-        // leaves both dimensions nil so the outer infinity frame fills it.
-        // Centering is that frame's default alignment, so no GeometryReader or
-        // `.position` is needed to letterbox a smaller device.
         return PinwheelHostedItem(item: item)
             .environment(\.horizontalSizeClass, horizontalSizeClass(for: device))
             .environment(\.verticalSizeClass, verticalSizeClass(for: device))
@@ -106,15 +90,14 @@ struct PinwheelPlayground: SwiftUI.View {
             return
         }
         didApplyPreviewTweak = true
-        // Defer past the current view update before mutating the example's state.
+        // Defer past the current view update — mutating state mid-update is undefined.
         DispatchQueue.main.async {
             tweak.applyAsPreviewVariant()
         }
     }
 
-    /// Dumps the current component's tweak titles (one per line) to the app's
-    /// Documents directory so external tooling — e.g. `Scripts/preview-all.sh` —
-    /// can enumerate variants without parsing source. Preview-mode only.
+    // Writes tweak titles (one per line) to Documents/pinwheel-preview-tweaks.txt;
+    // `Scripts/preview-all.sh` reads that file to enumerate a component's variants.
     private func writePreviewTweakTitles(_ titles: [String]) {
         guard let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
             return
@@ -145,15 +128,10 @@ struct PinwheelPlayground: SwiftUI.View {
     }
 }
 
-/// The floating pill showing the simulated device, pinned to the top of the
-/// playground and persisting after the settings sheet is dismissed. An indicator —
-/// only the reset `×` is interactive. Renders nothing on the real device.
 private struct PinwheelDevicePill: SwiftUI.View {
     @Environment(PinwheelChrome.self) private var chrome
 
     var body: some SwiftUI.View {
-        // Keyed on the same visibility the FAB uses, so closing dismisses both
-        // together and the pill's reset animates away.
         ZStack {
             if chrome.isDevicePillVisible, let device = chrome.simulatedDevice {
                 pill(for: device)
@@ -168,8 +146,6 @@ private struct PinwheelDevicePill: SwiftUI.View {
             Image(systemName: "iphone.gen3")
             PinLabel(device.title).font(.caption)
 
-            // Clearing the index both fades the pill and resizes the frame back to
-            // full — the playground animates on `selectedDeviceIndex`.
             SwiftUI.Button {
                 chrome.selectedDeviceIndex = nil
             } label: {
@@ -189,13 +165,8 @@ private struct PinwheelDevicePill: SwiftUI.View {
     }
 }
 
-/// Hosts a catalog item's SwiftUI view, building it exactly once (in `@State`) so
-/// its identity, `@State`, and emitted tweak preferences stay stable across
-/// playground re-renders — opening the settings sheet re-renders the playground,
-/// and rebuilding `item.swiftUIView()` each time would recreate the hosted view
-/// and transiently reset its tweak preference to empty (the settings sheet then
-/// showed no tweaks). One playground hosts one item, so identity is naturally
-/// stable for the playground's lifetime.
+// Builds the item's view once (in `@State`) so playground re-renders don't
+// recreate it and reset its emitted tweak preference to empty.
 private struct PinwheelHostedItem: SwiftUI.View {
     @SwiftUI.State private var view: AnyView
 
@@ -208,9 +179,6 @@ private struct PinwheelHostedItem: SwiftUI.View {
     }
 }
 
-/// The playground's settings: a tweaks-only "Options" screen with a device-icon
-/// nav button that pushes the device list. Devices are kept off the Options
-/// screen — selecting one resizes the playground and surfaces the device pill.
 private struct PinwheelSettingsView: SwiftUI.View {
     let tweaks: [PinwheelTweak]
     @SwiftUI.Binding var selectedDeviceIndex: Int?
@@ -283,8 +251,6 @@ private struct PinwheelSettingsView: SwiftUI.View {
     }
 }
 
-/// The pushed device list. Disabled devices (too big for the screen) are dimmed;
-/// the selected one is checked. Resetting to the real device is via the pill's `×`.
 private struct PinwheelDeviceList: SwiftUI.View {
     @SwiftUI.Binding var selectedIndex: Int?
 
@@ -323,7 +289,6 @@ private struct PinwheelDeviceList: SwiftUI.View {
         }
     }
 
-    /// With no explicit selection, the current (real) device is the active one.
     private func isSelected(_ index: Int, _ device: Device) -> Bool {
         if let selectedIndex { return selectedIndex == index }
         return device.isCurrent

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPreview.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPreview.swift
@@ -1,20 +1,8 @@
 import Foundation
 import SwiftUI
 
-/// Renders a single catalog component in isolation, resolved by id — the same
-/// isolated render the catalog shows when an item is opened, with no navigation
-/// scaffolding. This is the preview index: the existing `PinwheelSection`/
-/// `PinwheelItem` registry doubles as the list of previewable components, so a
-/// component becomes previewable the moment it is added to the catalog.
-///
-/// Two iteration paths build on this:
-/// - SwiftUI `#Preview` — `PinwheelPreview("button", sections: ...)`.
-/// - Deep-linking a host app straight to one component, bypassing the catalog
-///   (see `requestedID`): `simctl launch <bundle> -PinwheelPreview button`.
-///
-/// `id` accepts either a bare item id (`"button"`) or a qualified
-/// `"sectionID/itemID"` (`"components/button"`) to disambiguate items that share
-/// an id across sections.
+/// Renders one catalog component by id. `id` is a bare item id (`"button"`) or a
+/// qualified `"sectionID/itemID"` to disambiguate items that share an id.
 public struct PinwheelPreview: SwiftUI.View {
     private let sections: [PinwheelSection]
     private let id: String
@@ -55,8 +43,6 @@ public struct PinwheelPreview: SwiftUI.View {
         }
     }
 
-    /// Resolves a bare item id (`"button"`) or a qualified `"sectionID/itemID"`
-    /// to its section + item, or nil if absent.
     private static func resolve(
         id rawID: String,
         in sections: [PinwheelSection]
@@ -84,8 +70,6 @@ public struct PinwheelPreview: SwiftUI.View {
     }
 }
 
-/// A compact label baked into the preview render so a snapshot identifies the
-/// component (and active variant) without relying on the file name.
 private struct PinwheelPreviewCaption: SwiftUI.View {
     let id: String
     let variant: String?
@@ -102,20 +86,10 @@ private struct PinwheelPreviewCaption: SwiftUI.View {
 }
 
 public extension PinwheelPreview {
-    /// The component id requested for an isolated preview launch, if any — read
-    /// from the `-PinwheelPreview <id>` launch argument or the
-    /// `PINWHEEL_PREVIEW` environment variable. A host app branches on this to
-    /// deep-link straight to one component:
-    ///
-    /// ```swift
-    /// if let id = PinwheelPreview.requestedID {
-    ///     PinwheelPreview(id, sections: allSections)
-    /// } else {
-    ///     PinwheelCatalog { ... }
-    /// }
-    /// ```
+    /// The component id for an isolated preview launch: the `-PinwheelPreview <id>`
+    /// launch argument or the `PINWHEEL_PREVIEW` env var, else nil.
     static var requestedID: String? {
-        // UserDefaults surfaces `-PinwheelPreview <value>` launch arguments.
+        // `-key value` launch args are surfaced as UserDefaults values.
         if let argument = UserDefaults.standard.string(forKey: "PinwheelPreview"),
            !argument.isEmpty {
             return argument
@@ -129,10 +103,8 @@ public extension PinwheelPreview {
         return nil
     }
 
-    /// The tweak/variant to auto-apply on a preview launch, if any — read from
-    /// the `-PinwheelPreviewTweak <title>` launch argument or the
-    /// `PINWHEEL_PREVIEW_TWEAK` environment variable. Lets tooling deep-link
-    /// straight to a variant (e.g. the StateView "Failed" state).
+    /// The tweak/variant to auto-apply on a preview launch: the
+    /// `-PinwheelPreviewTweak <title>` launch argument or `PINWHEEL_PREVIEW_TWEAK`, else nil.
     static var requestedTweak: String? {
         if let argument = UserDefaults.standard.string(forKey: "PinwheelPreviewTweak"),
            !argument.isEmpty {

--- a/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinButton.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinButton.swift
@@ -1,18 +1,5 @@
 import SwiftUI
 
-/// SwiftUI-native pill button: themed styles, an optional SF Symbol, a loading
-/// state, and press feedback. Mirrors SwiftUI's `Button(_:systemImage:action:)`;
-/// visual style and loading are chained modifiers, like SwiftUI's `.buttonStyle`.
-///
-/// ```swift
-/// PinButton("Save") { save() }
-/// PinButton("Continue", systemImage: "arrow.right") { go() }.style(.secondary)
-/// PinButton("Saving") { }.loading(isSaving)
-/// PinButton(systemImage: "arrow.right") { }            // symbol-only
-/// ```
-///
-/// The button owns its type style (`subtitleSemibold`); `.custom` is the escape
-/// hatch for one-off colors.
 public struct PinButton: SwiftUI.View {
     public enum Style: Equatable {
         case primary
@@ -50,22 +37,18 @@ public struct PinButton: SwiftUI.View {
         self.action = action
     }
 
-    /// Sets the visual style (default `.primary`).
     public func style(_ style: Style) -> PinButton {
         var copy = self
         copy.style = style
         return copy
     }
 
-    /// Sets the title/symbol typography (default `.subtitleSemibold`). Takes a
-    /// themed `PinTextStyle`, not a raw `Font`, so it stays on the design system.
     public func font(_ style: PinTextStyle) -> PinButton {
         var copy = self
         copy.typography = style
         return copy
     }
 
-    /// Shows a loading spinner alongside the content (default `true`).
     public func loading(_ isLoading: Bool = true) -> PinButton {
         var copy = self
         copy.isLoading = isLoading
@@ -142,10 +125,7 @@ private struct PinButtonStyle: SwiftUI.ButtonStyle {
         private var foreground: SwiftUI.Color {
             switch style {
             case .primary:
-                // The label sits on the action-colored fill, so it's the surface
-                // token — the inverse of the FAB (primaryBackground surface +
-                // actionText accent). Never hard-code white: a provider with a
-                // pale action color would render invisible text.
+                // The label sits on the action-colored fill, so it's the surface token; hard-coding white renders invisible on a pale action color.
                 return .primaryBackground
             case .secondary:
                 return isEnabled ? .primaryText : .tertiaryText

--- a/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinLabel.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinLabel.swift
@@ -1,29 +1,10 @@
 import SwiftUI
 
-/// SwiftUI-native themed text — the counterpart to the UIKit `UIKitPinLabel`.
-///
-/// Prefer this over `Text(...).font(.body)`: SwiftUI's built-in `.body` / `.title`
-/// are *Apple's* system text styles that share names with the design system but
-/// silently bypass it. `PinLabel` always resolves the provider-backed
-/// `PinwheelTheme.Typography` font. Taking a `PinTextStyle` (not a raw `Font`) is
-/// deliberate — it makes the wrong, system-font path unrepresentable.
-///
-/// Styling reads like SwiftUI — `.font(_:)` matches `PinButton.font(_:)`; the font
-/// defaults to `.body` and color to `.primary`, so the common case is just the text:
-///
-/// ```swift
-/// PinLabel("Has chevron")                                 // body, primary
-/// PinLabel("Title").font(.title)
-/// PinLabel("subtitle").font(.caption).color(.secondary)   // .custom(_) for arbitrary colors
-/// ```
-///
-/// `PinLabel` is a pure SwiftUI value (no `UIHostingController`): Label is the one
-/// component where SwiftUI and UIKit each have an independent trivial implementation
-/// fed by the same `Config` provider tokens, so neither needs to host the other.
+/// SwiftUI's built-in `.body` / `.title` are Apple's system text styles that share
+/// names with the design system but silently bypass it; `PinLabel` resolves the
+/// provider-backed font, and taking a `PinTextStyle` (not a raw `Font`) makes the
+/// system-font path unrepresentable.
 public struct PinLabel: SwiftUI.View {
-    /// A themed text color role. Use the semantic cases to stay on the design
-    /// system; `.custom(_)` is the escape hatch for an arbitrary color (named to
-    /// match `PinButton.Style.custom`).
     public enum TextColor {
         case primary
         case secondary
@@ -52,15 +33,12 @@ public struct PinLabel: SwiftUI.View {
         self.text = text
     }
 
-    /// Sets the typography (default `.body`).
     public func font(_ font: PinTextStyle) -> PinLabel {
         var copy = self
         copy.typography = font
         return copy
     }
 
-    /// Sets the text color role (default `.primary`). Use `.custom(_)` for an
-    /// arbitrary color.
     public func color(_ color: TextColor) -> PinLabel {
         var copy = self
         copy.color = color

--- a/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinList.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinList.swift
@@ -1,18 +1,5 @@
 import SwiftUI
 
-/// SwiftUI-native themed list with a built-in loading / empty / failed state —
-/// the SwiftUI counterpart of `UIKitPinTableView`. `.loaded` renders the themed
-/// rows; any other `PinState` renders a `PinStateView` overlay (reusing the same
-/// state machine the UIKit table uses).
-///
-/// ```swift
-/// PinList(state: phase, rows: [
-///     .text("Only title"),
-///     .text("Title", subtitle: "sub", detail: "Detail", chevron: true) { open() },
-///     .text("Is disabled", enabled: false),
-///     .toggle("Notifications", isOn: $on),
-/// ], onRetry: retry)
-/// ```
 public struct PinList: SwiftUI.View {
     private let state: PinState
     private let rows: [Row]
@@ -27,8 +14,7 @@ public struct PinList: SwiftUI.View {
     public var body: some SwiftUI.View {
         switch state {
         case .loaded:
-            // Rows are a fixed value array per render, so positional identity is
-            // stable; there is no per-row id to key on.
+            // No per-row id to key on; positional identity is stable because rows are a fixed value array per render.
             List(Array(rows.enumerated()), id: \.offset) { _, row in
                 row.listRowBackground(PinwheelTheme.Colors.primaryBackground)
             }
@@ -42,8 +28,6 @@ public struct PinList: SwiftUI.View {
 }
 
 public extension PinList {
-    /// A row in a `PinList`. Built with the `.text` / `.toggle` factories so the
-    /// common case stays terse (defaults) while toggles carry a `Binding`.
     struct Row: SwiftUI.View {
         private enum Kind {
             case text(subtitle: String?, detail: String?, chevron: Bool, enabled: Bool, action: (() -> Void)?)
@@ -58,9 +42,6 @@ public extension PinList {
             self.kind = kind
         }
 
-        /// A text row: title, optional subtitle, optional trailing detail, an
-        /// optional chevron, and an optional tap `action`. `enabled: false` dims
-        /// it and makes it non-interactive.
         public static func text(
             _ title: String,
             subtitle: String? = nil,
@@ -72,8 +53,6 @@ public extension PinList {
             Row(title: title, kind: .text(subtitle: subtitle, detail: detail, chevron: chevron, enabled: enabled, action: action))
         }
 
-        /// A switch row bound to `isOn`. `enabled: false` dims it and makes it
-        /// non-interactive.
         public static func toggle(_ title: String, subtitle: String? = nil, enabled: Bool = true, isOn: Binding<Bool>) -> Row {
             Row(title: title, kind: .toggle(subtitle: subtitle, enabled: enabled, isOn: isOn))
         }

--- a/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinState.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinState.swift
@@ -1,10 +1,4 @@
-/// The content state shared by the components that present loading / empty /
-/// failed placeholders — `PinStateView` (as an overlay) and `PinList` (gating
-/// its rows). Promoted to a top-level type, like `PinTextStyle`, so neither
-/// component "owns" the vocabulary the other reuses.
-///
-/// `.loaded` carries no copy: it means "show your content" — `PinStateView`
-/// renders nothing, `PinList` shows its rows.
+/// `.loaded` means "show your content": `PinStateView` renders nothing, `PinList` shows its rows.
 public enum PinState: Equatable {
     case loading(title: String, subtitle: String)
     case loaded

--- a/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinStateView.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinStateView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
-/// SwiftUI-native counterpart of the UIKit state view. Renders a centered
-/// loading / empty / failed placeholder; `.loaded` renders nothing, so it can
-/// sit as an overlay that reveals the underlying content once loaded.
+/// `.loaded` renders nothing, so this can sit as an overlay that reveals the underlying content once loaded.
 public struct PinStateView: SwiftUI.View {
     private let state: PinState
     private let onAction: () -> Void

--- a/Pinwheel/Sources/Pinwheel/Components/UIKit/TableView/UIKitPinTableView.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/UIKit/TableView/UIKitPinTableView.swift
@@ -23,15 +23,11 @@ public enum UIKitPinTableViewState {
     case failed(title: String, subtitle: String, actionTitle: String)
 }
 
-/// Intentional UIKit surface (not a thin host over SwiftUI). Cell recycling, the
-/// dataSource/delegate contract, `UISwitch` items and the A–Z section indexer
-/// have no `List` equivalent with comparable ergonomics/perf, so it stays UIKit.
-/// Its state overlay is the SwiftUI-backed `UIKitPinStateView` shell.
+/// Stays UIKit: cell recycling, the dataSource/delegate contract, `UISwitch` items
+/// and the A–Z section indexer have no `List` equivalent with comparable perf.
 open class UIKitPinTableView: ShadowScrollView {
     public static let estimatedRowHeight: CGFloat = 60.0
     open var selectedIndexPath: IndexPath?
-
-    // MARK: - Internal properties
 
     private lazy var tableView: UITableView = {
         let tableView = UITableView(withAutoLayout: true)
@@ -83,8 +79,6 @@ open class UIKitPinTableView: ShadowScrollView {
         return view
     }()
 
-    // MARK: - Setup
-
     public init(dataSource: UIKitPinTableViewDataSource, usingShadowWhenScrolling: Bool = false) {
         self.usingShadowWhenScrolling = usingShadowWhenScrolling
         self.dataSource = dataSource
@@ -126,7 +120,6 @@ open class UIKitPinTableView: ShadowScrollView {
     }
 }
 
-// MARK: - UITableViewDelegate
 extension UIKitPinTableView: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
@@ -147,7 +140,6 @@ extension UIKitPinTableView: UITableViewDelegate {
     }
 }
 
-// MARK: - UITableViewDataSource
 extension UIKitPinTableView: UITableViewDataSource {
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if let dataSource = self.dataSource {

--- a/Pinwheel/Sources/Pinwheel/Components/UIKit/TableView/UIKitPinTableViewCell.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/UIKit/TableView/UIKitPinTableViewCell.swift
@@ -7,8 +7,6 @@ public protocol UIKitPinTableViewCellDelegate: AnyObject {
 open class UIKitPinTableViewCell: UITableViewCell {
     weak var delegate: UIKitPinTableViewCellDelegate?
 
-    // MARK: - Public properties
-
     open var selectedIndexPath: IndexPath?
     open var isEnabled: Bool = true
 
@@ -63,12 +61,8 @@ open class UIKitPinTableViewCell: UITableViewCell {
     open lazy var detailLabelTrailingConstraint = detailLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
     open lazy var switchControlTrailingConstraint = switchControl.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
 
-    // MARK: - Private properties
-
     private lazy var stackViewToDetailLabelConstraint = stackView.trailingAnchor.constraint(lessThanOrEqualTo: detailLabel.leadingAnchor, constant: -.spacingXS)
     private lazy var stackViewToSwitchControlConstraint = stackView.trailingAnchor.constraint(lessThanOrEqualTo: switchControl.leadingAnchor, constant: -.spacingXS)
-
-    // MARK: - Setup
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -78,8 +72,6 @@ open class UIKitPinTableViewCell: UITableViewCell {
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    // MARK: - Public methods
 
     public var indexPath: IndexPath?
 
@@ -143,8 +135,6 @@ open class UIKitPinTableViewCell: UITableViewCell {
         subtitleLabel.text = nil
         detailLabel.text = nil
     }
-
-    // MARK: - Private methods
 
     private func setup() {
         setDefaultSelectedBackgound()

--- a/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinButton.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinButton.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import UIKit
 
-/// UIKit-facing style for `UIKitPinButton`, mapped onto the SwiftUI `PinButton.Style`.
 public enum UIKitPinButtonStyle {
     case primary
     case secondary
@@ -25,11 +24,6 @@ public enum UIKitPinButtonStyle {
     }
 }
 
-/// UIKit-friendly host over the SwiftUI `PinButton`. There is a single button
-/// implementation — the SwiftUI `PinButton` — and this is a thin shell that gives
-/// a hybrid UIKit app the imperative ergonomics it expects (title / isEnabled /
-/// isLoading mutation and target-action), so no SwiftUI knowledge is needed at the
-/// call site.
 public final class UIKitPinButton: UIControl {
     private let systemImage: String?
     private let font: PinTextStyle
@@ -40,7 +34,7 @@ public final class UIKitPinButton: UIControl {
     public var isLoading: Bool = false { didSet { reload() } }
     public override var isEnabled: Bool { didSet { reload() } }
 
-    /// Modern tap handler. `addTarget(_:action:for: .touchUpInside)` also works.
+    /// `addTarget(_:action:for: .touchUpInside)` also fires.
     public var onTap: (() -> Void)?
 
     public init(
@@ -71,7 +65,6 @@ public final class UIKitPinButton: UIControl {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Compatibility with the old UIKit API.
     public func showActivityIndicator(_ shouldShow: Bool) {
         isLoading = shouldShow
     }

--- a/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinFullscreenView.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinFullscreenView.swift
@@ -1,8 +1,5 @@
 import UIKit
 
-/// Intentional UIKit surface (not a thin host over SwiftUI). Keyboard avoidance,
-/// view-lifecycle hooks and open subclassing are inherently UIKit here; bridging
-/// to SwiftUI would not match the ergonomics or behavior, so it stays UIKit.
 open class UIKitPinFullscreenView: UIView {
     public override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinLabel.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinLabel.swift
@@ -1,12 +1,6 @@
 import UIKit
 
-/// Trivial themed `UILabel` subclass. Label is the one component where SwiftUI
-/// and UIKit each get an independent trivial implementation fed by the same
-/// `Config` provider tokens — no hosting bridge in either direction. The SwiftUI
-/// counterpart is `PinLabel` (a themed `Text`).
 public class UIKitPinLabel: UILabel {
-    // MARK: - Setup
-
     public init(font: UIFont = .body, textColor: UIColor = .primaryText) {
         super.init(frame: .zero)
         setup(font: font, textColor: textColor)

--- a/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinStateView.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinStateView.swift
@@ -5,7 +5,6 @@ public protocol UIKitPinStateViewDelegate: AnyObject {
     func stateViewDidSelectAction(_ stateView: UIKitPinStateView)
 }
 
-/// UIKit-facing state, mapped onto the SwiftUI `PinState`.
 public enum UIKitPinStateViewState {
     case loading(title: String, subtitle: String)
     case loaded
@@ -31,20 +30,13 @@ public enum UIKitPinStateViewState {
     }
 }
 
-/// UIKit-friendly host over the SwiftUI `PinStateView`. There is a single state
-/// view implementation — the SwiftUI `PinStateView` — and this is a thin shell
-/// that gives a hybrid UIKit app the imperative ergonomics it expects (`state`
-/// mutation and a delegate/closure action callback), so no SwiftUI knowledge is
-/// needed at the call site.
 public final class UIKitPinStateView: UIView {
     public weak var delegate: UIKitPinStateViewDelegate?
 
-    /// Modern action handler for the failed-state button. The `delegate` also fires.
+    /// The `delegate` also fires.
     public var onAction: (() -> Void)?
 
-    // The view hides itself in `.loaded` (mirroring the old overlay behavior),
-    // so consumers that pin it over content — e.g. UIKitPinTableView — reveal
-    // the content underneath without managing the overlay's alpha themselves.
+    // Hides itself in `.loaded`, so consumers pinning it over content reveal the content underneath without managing alpha.
     public var state: UIKitPinStateViewState = .loaded {
         didSet {
             alpha = state.isLoaded ? 0 : 1
@@ -63,8 +55,6 @@ public final class UIKitPinStateView: UIView {
 
         host = PinHostView(rootView: makeRootView())
         addSubview(host)
-        // Hugs its content and centers vertically, matching the placeholder's
-        // centered layout when pinned over content (e.g. a table's overlay).
         NSLayoutConstraint.activate([
             host.leadingAnchor.constraint(equalTo: leadingAnchor),
             host.trailingAnchor.constraint(equalTo: trailingAnchor),

--- a/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinView.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/UIKit/UIKitPinView.swift
@@ -1,8 +1,6 @@
 import UIKit
 
-/// Intentional UIKit surface (not a thin host over SwiftUI). This base view
-/// exists for open subclassing and the `setup()` lifecycle hook that UIKit
-/// example/screen code relies on — there is no comparable SwiftUI seam to bridge.
+/// Base view for open subclassing; override `setup()` for post-init configuration.
 open class UIKitPinView: UIView {
     public override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Pinwheel/Sources/Pinwheel/Extensions/ArrayExtensions.swift
+++ b/Pinwheel/Sources/Pinwheel/Extensions/ArrayExtensions.swift
@@ -1,5 +1,4 @@
 public extension Array {
-    /// Returns nil if index < count
     subscript(safe index: Int) -> Element? {
         return indices.contains(index) ? self[index] : .none
     }

--- a/Pinwheel/Sources/Pinwheel/Extensions/KeyboardNotificationInfo.swift
+++ b/Pinwheel/Sources/Pinwheel/Extensions/KeyboardNotificationInfo.swift
@@ -28,12 +28,9 @@ public struct KeyboardNotificationInfo {
         frameEnd = userInfo[UIWindow.keyboardFrameEndUserInfoKey] as? CGRect
     }
 
-    /// Calculate the total intersection between the keyboard and a view. The value returned
-    /// will be between 0 and whatever intersection occurs. This is in case the user has
-    /// an iPad with an external keyboard connected, which would've returned a negative value.
+    /// Clamped to >= 0 so an iPad with an external keyboard (which would report a negative intersection) reads as no overlap.
     public func keyboardFrameEndIntersectHeight(inView view: UIView) -> CGFloat {
-        // The Prefer Cross-Fade Transitions setting causes empty frameEnd,
-        // so we need to check for this to support the setting.
+        // The Prefer Cross-Fade Transitions accessibility setting leaves frameEnd empty.
         guard let frameEnd = frameEnd, !frameEnd.isEmpty else { return 0 }
         let frameInWindow = view.convert(view.bounds, to: nil)
         let intersection = frameEnd.intersection(frameInWindow)
@@ -46,8 +43,6 @@ public struct KeyboardNotificationInfo {
         return max(0, intersection.height + outOfBoundsHeight - safeInsetBottom)
     }
 }
-
-// MARK: - Private extensions
 
 private extension Notification {
     var keyboardNotificationAction: KeyboardNotificationInfo.KeyboardAction? {

--- a/Pinwheel/Sources/Pinwheel/Extensions/LayoutHelpers.swift
+++ b/Pinwheel/Sources/Pinwheel/Extensions/LayoutHelpers.swift
@@ -1,14 +1,6 @@
 import UIKit
 
 public extension UIEdgeInsets {
-    /// Helper initializer to reduce the amount of values required to create a UIEdgeInsets, so you can do
-    /// for example UIEdgeInsets(leading: 20).
-    ///
-    /// - Parameters:
-    ///   - top:  Specify an amount to add a margin on the top anchor.
-    ///   - leading: Specify an amount to add a margin on the leading anchor.
-    ///   - bottom: Specify a negative amount to add a margin on the bottom anchor.
-    ///   - trailing: Specify a negative amount to add a margin on the trailing anchor.
     init(top: CGFloat = 0, leading: CGFloat = 0, bottom: CGFloat = 0, trailing: CGFloat = 0) {
         self.init(top: top, left: leading, bottom: bottom, right: trailing)
     }

--- a/Pinwheel/Sources/Pinwheel/Extensions/UIColorExtensions.swift
+++ b/Pinwheel/Sources/Pinwheel/Extensions/UIColorExtensions.swift
@@ -1,9 +1,6 @@
 import UIKit
 
 extension UIColor {
-    /// Base initializer, it creates an instance of `UIColor` using an HEX string.
-    ///
-    /// - Parameter hex: The base HEX string to create the color.
     public convenience init(hex: String) {
         let noHashString = hex.replacingOccurrences(of: "#", with: "")
         let scanner = Scanner(string: noHashString)
@@ -21,11 +18,7 @@ extension UIColor {
         }
     }
 
-    /// Convenience method to create dynamic colors for dark mode if the OS supports it (independant of Pinwheel
-    /// settings)
-    /// - Parameters:
-    ///   - defaultColor: light mode version of the color
-    ///   - darkModeColor: dark mode version of the color
+    /// Resolves dynamically per system dark mode, independent of Pinwheel settings.
     @available(iOS 13.0, *)
     public class func dynamicColor(defaultColor: UIColor, darkModeColor: UIColor) -> UIColor {
         UIColor { traitCollection -> UIColor in
@@ -38,13 +31,11 @@ extension UIColor {
         }
     }
 
-    /// Returns hexadecimal representation of a color converted to the sRGB color space.
     var hexString: String {
         guard
             let targetColorSpace = CGColorSpace(name: CGColorSpace.sRGB),
             let cgColor = self.cgColor.converted(to: targetColorSpace, intent: .relativeColorimetric, options: nil)
         else {
-            // Not possible to convert source color space to RGB
             return "#000000"
         }
         let components = cgColor.components

--- a/Pinwheel/Sources/Pinwheel/Extensions/UITraitCollectionExtensions.swift
+++ b/Pinwheel/Sources/Pinwheel/Extensions/UITraitCollectionExtensions.swift
@@ -1,8 +1,7 @@
 import UIKit
 
 extension UITraitCollection {
-    /// This method is intented to be used where `traitCollection` is not available, for example
-    /// outside of views or view controllers. Given the idea is to identify if the horizontal size class is regular.
+    /// For use where a `traitCollection` is unavailable, e.g. outside views or view controllers.
     public static var isHorizontalSizeClassRegular: Bool {
         if #available(iOS 13.0, *) {
             return current.horizontalSizeClass == .regular

--- a/Pinwheel/Sources/Pinwheel/Extensions/UIViewExtensions.swift
+++ b/Pinwheel/Sources/Pinwheel/Extensions/UIViewExtensions.swift
@@ -6,7 +6,6 @@ public extension UIView {
         translatesAutoresizingMaskIntoConstraints = !autoLayout
     }
 
-    /// The nearest view controller in the responder chain, if any.
     var parentViewController: UIViewController? {
         var responder: UIResponder? = next
         while let current = responder {
@@ -36,9 +35,7 @@ public extension UIView {
 }
 
 extension UIViewController {
-    /// Applies a simulated device's traits via `traitOverrides` — the
-    /// replacement for the deprecated `setOverrideTraitCollection(_:forChild:)`,
-    /// called on the child whose traits should be overridden.
+    /// Replaces the deprecated `setOverrideTraitCollection(_:forChild:)`; call on the child whose traits to override.
     func applyDeviceTraitOverrides(_ traits: UITraitCollection) {
         traitOverrides.horizontalSizeClass = traits.horizontalSizeClass
         traitOverrides.verticalSizeClass = traits.verticalSizeClass

--- a/Pinwheel/Sources/Pinwheel/Tokens/Color/UIColor+Pinwheel.swift
+++ b/Pinwheel/Sources/Pinwheel/Tokens/Color/UIColor+Pinwheel.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-// MARK: - Semantic colors, dark mode compatible
 extension UIColor {
     public class var primaryText: UIColor { Config.colorProvider.primaryText }
     public class var secondaryText: UIColor { Config.colorProvider.secondaryText }

--- a/Pinwheel/Sources/Pinwheel/Tokens/PinwheelTheme.swift
+++ b/Pinwheel/Sources/Pinwheel/Tokens/PinwheelTheme.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 import UIKit
 
-/// The themed typography scale — the font token used by `PinLabel.font(_:)` and
-/// `PinButton.font(_:)`. Parallels Apple's `Font.TextStyle`, but resolves the
-/// provider-backed `PinwheelTheme.Typography` fonts instead of system styles.
+/// Parallels Apple's `Font.TextStyle`, but resolves provider-backed
+/// `PinwheelTheme.Typography` fonts instead of system styles.
 public enum PinTextStyle {
     case title
     case subtitle
@@ -24,9 +23,8 @@ public enum PinTextStyle {
     }
 }
 
-/// The deliberate UIKit→SwiftUI token adaptor: every token resolves a
-/// provider-backed `UIFont`/`UIColor` (via the `Config` providers) and wraps it
-/// as a SwiftUI `Font`/`Color`, so both worlds stay on the same design tokens.
+/// Wraps the provider-backed `UIFont`/`UIColor` tokens as SwiftUI `Font`/`Color`,
+/// so both worlds stay on the same design tokens.
 public enum PinwheelTheme {
     public enum Typography {
         public static var title: Font { Font(UIFont.title) }
@@ -51,9 +49,8 @@ public enum PinwheelTheme {
     }
 }
 
-/// SwiftUI-native shorthand for the themed colors — `.background(.primaryBackground)`,
-/// like `.red`. Forwards to the canonical `PinwheelTheme.Colors`. Can't reach
-/// `.listRowBackground(_:)`, whose parameter is a generic `View`, not a `ShapeStyle`.
+/// `.red`-style shorthand for the themed colors. Can't reach `.listRowBackground(_:)`,
+/// whose parameter is a generic `View`, not a `ShapeStyle`.
 public extension ShapeStyle where Self == Color {
     static var primaryText: Color { PinwheelTheme.Colors.primaryText }
     static var secondaryText: Color { PinwheelTheme.Colors.secondaryText }

--- a/Pinwheel/Sources/Pinwheel/Tokens/Spacing/Spacing.swift
+++ b/Pinwheel/Sources/Pinwheel/Tokens/Spacing/Spacing.swift
@@ -12,50 +12,41 @@ public struct SpacingValues {
 }
 
 public extension CGFloat {
-
-    /// Spacing 2 points.
     static var spacingXXS: CGFloat {
         get { SpacingValues.spacingXXS }
         set { SpacingValues.spacingXXS = newValue }
     }
 
-    /// Spacing 4 points.
     static var spacingXS: CGFloat {
         get { SpacingValues.spacingXS }
         set { SpacingValues.spacingXS = newValue }
     }
 
-    /// Spacing 6 points.
     static var spacingXM: CGFloat {
         get { SpacingValues.spacingXM }
         set { SpacingValues.spacingXM = newValue }
     }
 
-    /// Spacing 8 points.
     static var spacingS: CGFloat {
         get { SpacingValues.spacingS }
         set { SpacingValues.spacingS = newValue }
     }
 
-    /// Spacing 12 points.
     static var spacingM: CGFloat {
         get { SpacingValues.spacingM }
         set { SpacingValues.spacingM = newValue }
     }
 
-    /// Spacing 16 points.
     static var spacingL: CGFloat {
         get { SpacingValues.spacingL }
         set { SpacingValues.spacingL = newValue }
     }
 
-    /// Spacing 24 points.
     static var spacingXL: CGFloat {
         get { SpacingValues.spacingXL }
         set { SpacingValues.spacingXL = newValue }
     }
 
-    /// Spacing 32 points.
     static var spacingXXL: CGFloat {
         get { SpacingValues.spacingXXL }
         set { SpacingValues.spacingXXL = newValue }


### PR DESCRIPTION
A ruthless comment/docstring audit across all first-party Swift (`Pinwheel/Sources`, `Demo`, `DemoUITests`, `DemoCatalog`). A comment survived only if the code is materially worse off without it — an external/framework quirk, a *why* that stops a wrong "fix", a gotcha the type system can't state, or a justification for suspicious-looking code. Everything else — narration, signature restatement, docstrings that just expand the name, `// MARK` banners, status notes — is gone.

**~477 comment lines deleted, ~40 trimmed survivors.** A sample of what earned its place:
- `Don't animate the device-frame resize — it recurses SwiftUI's layout into a stack overflow` (crash trap)
- `Reuse one instance across re-renders … a fresh view per call would leave tweaks mutating an off-screen copy` (silent no-op trap)
- `Over empty areas UIWindow.hitTest returns the window itself` (pass-through FAB gotcha)
- `PinLabel takes a PinTextStyle, not a raw Font, so the system-font path is unrepresentable` (theme footgun)
- `Clamped to >= 0 so an external keyboard's negative intersection reads as no overlap` (empirical UIKit quirk)

Verified behavior-neutral: the diff is **comment-only** (zero non-comment lines changed), the app + test target build clean, and all **11 DemoUITests pass**.