### PR TITLE
UI-test trial: push logic down to units, keep only app-layer UI tests

### DIFF
--- a/DemoUITests/StateViewUITests.swift
+++ b/DemoUITests/StateViewUITests.swift
@@ -1,10 +1,10 @@
 import XCTest
 import DemoCatalog
 
-/// Exercises the StateView through the deep-link preview (`-PinwheelPreview <id>`),
-/// covering interactions that screenshots can't verify headlessly: opening the
-/// playground settings, switching to the failed state via a tweak, and tapping
-/// the failed-state action ("Retry").
+/// App-layer wiring the unit layer can't reach: `PinStateView`'s failed-state
+/// action button firing and the view transitioning, across SwiftUI and the two
+/// UIKit hosting seams (`view:` and `viewController:`). The state values are data;
+/// only the button → transition → render glue needs a running UI.
 final class StateViewUITests: XCTestCase {
     private var app: XCUIApplication!
 
@@ -43,14 +43,8 @@ final class StateViewUITests: XCTestCase {
         failed.tap()
     }
 
-    // MARK: - SwiftUI PinStateView
-
-    @MainActor
-    func testSwiftUIStateViewRendersDefaultEmptyState() {
-        launchPreview(.stateView, .swiftUI)
-        XCTAssertTrue(app.staticTexts["Ready to Move?"].waitForExistence(timeout: defaultTimeout))
-    }
-
+    // KEEP: app-layer wiring — the SwiftUI failed-state action button fires and
+    // PinStateView transitions to loading.
     @MainActor
     func testSwiftUIStateViewRetryTriggersLoading() {
         launchPreview(.stateView, .swiftUI)
@@ -65,8 +59,8 @@ final class StateViewUITests: XCTestCase {
                       "Tapping Retry should switch the SwiftUI state view to loading")
     }
 
-    // MARK: - UIKit shell (UIKitPinStateView over PinStateView)
-
+    // KEEP: app-layer wiring — the UIKitPinStateView shell hosts PinStateView and
+    // bridges the retry action to its delegate.
     @MainActor
     func testUIKitStateViewBridgesTweaksAndRetry() {
         launchPreview(.stateView, .uiKit)
@@ -81,12 +75,8 @@ final class StateViewUITests: XCTestCase {
                       "Tapping Retry should fire the delegate and switch the UIKit state view to loading")
     }
 
-    // MARK: - UIKit view-controller host (UIKitPinStateView inside a UIViewController)
-
-    /// Same contract as the `view:`-hosted case above, but through the
-    /// `PinwheelItem(viewController:)` path — guards that a `UIViewController`'s
-    /// `Tweakable` tweaks bridge into the settings sheet and that the retry tap
-    /// drives the live (on-screen) instance, not an off-screen copy.
+    // KEEP: app-layer wiring — the `viewController:` hosting seam bridges Tweakable
+    // into the sheet and drives the live on-screen instance, not an off-screen copy.
     @MainActor
     func testUIKitViewControllerStateViewBridgesTweaksAndRetry() {
         launchPreview(.viewController, .uiKit)

--- a/DemoUITests/TweakableUITests.swift
+++ b/DemoUITests/TweakableUITests.swift
@@ -1,10 +1,11 @@
 import XCTest
 import DemoCatalog
 
-/// Exercises the Tweakable examples through the deep-link preview
-/// (`-PinwheelPreview <id>`): opening the playground settings and choosing an
-/// option should mutate the example's content. Covers both the SwiftUI
-/// `pinwheelTweaks` path and the UIKit `Tweakable` → `PinwheelTweak` bridge.
+/// App-layer wiring for tweaks that a unit can't reach: the settings sheet →
+/// content re-render, nested catalog presentation, and UIKit hosting. The tweak
+/// model and the `Tweakable` → `PinwheelTweak` bridge logic are unit-tested in
+/// `PinwheelTweakTests`; these guard only the glue. Grow unit coverage by default
+/// — a new UI test here is the exception, justified by an app-layer fact.
 final class TweakableUITests: XCTestCase {
     private var app: XCUIApplication!
 
@@ -59,37 +60,9 @@ final class TweakableUITests: XCTestCase {
         item.tap()
     }
 
-    // MARK: - SwiftUI pinwheelTweaks
-
-    @MainActor
-    func testSwiftUIActionTweakUpdatesContent() {
-        launchPreview(.tweakable, .swiftUI)
-        openSettings()
-
-        let option1 = app.buttons["Option 1"]
-        XCTAssertTrue(option1.waitForExistence(timeout: defaultTimeout), "Option 1 should be listed")
-        option1.tap()
-
-        XCTAssertTrue(app.staticTexts["Chosen Option 1"].waitForExistence(timeout: defaultTimeout),
-                      "Choosing an action tweak should update the example label")
-    }
-
-    @MainActor
-    func testSwiftUIToggleTweakUpdatesContent() {
-        launchPreview(.tweakable, .swiftUI)
-        openSettings()
-
-        let option3 = app.switches["Option 3, Toggle-backed option"]
-        XCTAssertTrue(option3.waitForExistence(timeout: defaultTimeout), "Option 3 toggle should be listed")
-        // The row is a single combined element; tapping its center hits the label,
-        // so tap the switch control on the trailing edge to actually flip it.
-        option3.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5)).tap()
-
-        // The label updates behind the sheet (no Done button to dismiss anymore).
-        XCTAssertTrue(app.staticTexts["Option 3 is on"].waitForExistence(timeout: defaultTimeout),
-                      "Toggling a bool tweak should update the example label")
-    }
-
+    // KEEP: app-layer wiring — tweak preferences survive the settings sheet
+    // closing and reopening across a playground re-render. (Tweak invocation
+    // itself is unit-tested in PinwheelTweakTests.)
     @MainActor
     func testSwiftUISecondActionTweakStillUpdatesContent() {
         launchPreview(.tweakable, .swiftUI)
@@ -110,8 +83,8 @@ final class TweakableUITests: XCTestCase {
                       "A second tweak selection should still update the example label")
     }
 
-    // MARK: - Catalog navigation (the real user path: nested presentation)
-
+    // KEEP: app-layer wiring — the real user path (catalog list → fullScreenCover
+    // → playground → sheet) that a unit can't drive.
     @MainActor
     func testCatalogTweakableActionUpdatesContent() {
         app.launch()
@@ -127,8 +100,8 @@ final class TweakableUITests: XCTestCase {
                       "Choosing a tweak from the catalog (nested presentation) should update the label")
     }
 
-    // MARK: - UIKit Tweakable bridge
-
+    // KEEP: app-layer wiring — the UIKit Tweakable bridge end-to-end plus hosting
+    // driving the on-screen instance (the mapping itself is in PinwheelTweakTests).
     @MainActor
     func testCatalogUIKitTweakableActionUpdatesContent() {
         app.launch()
@@ -144,8 +117,7 @@ final class TweakableUITests: XCTestCase {
                       "A UIKit tweak chosen from the catalog should update the hosted view's label")
     }
 
-    // MARK: - Device selection (repro)
-
+    // KEEP: app-layer wiring — a SwiftUI layout-engine crash no unit can reproduce.
     @MainActor
     func testSelectingSimulatedDeviceDoesNotCrash() {
         launchPreview(.tweakable, .swiftUI)
@@ -166,18 +138,5 @@ final class TweakableUITests: XCTestCase {
         // (a crashed/hung app fails this query rather than returning at once).
         XCTAssertTrue(app.buttons["iPhone SE (2nd & 3rd generation)"].waitForExistence(timeout: defaultTimeout),
                       "device list should stay responsive after selecting a device")
-    }
-
-    @MainActor
-    func testUIKitActionTweakUpdatesContent() {
-        launchPreview(.tweakable, .uiKit)
-        openSettings()
-
-        let option1 = app.buttons["Option 1"]
-        XCTAssertTrue(option1.waitForExistence(timeout: defaultTimeout), "bridged Option 1 should be listed")
-        option1.tap()
-
-        XCTAssertTrue(app.staticTexts["Chosen Option 1!\n\nYou can drag the button too :D"].waitForExistence(timeout: defaultTimeout),
-                      "A bridged UIKit action tweak should update the example label")
     }
 }

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPreview.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPreview.swift
@@ -57,7 +57,7 @@ public struct PinwheelPreview: SwiftUI.View {
 
     /// Resolves a bare item id (`"button"`) or a qualified `"sectionID/itemID"`
     /// to its section + item, or nil if absent.
-    private static func resolve(
+    static func resolve(
         id rawID: String,
         in sections: [PinwheelSection]
     ) -> (section: PinwheelSection, item: PinwheelItem)? {

--- a/Pinwheel/Tests/PinwheelTests/PinwheelPreviewResolveTests.swift
+++ b/Pinwheel/Tests/PinwheelTests/PinwheelPreviewResolveTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import SwiftUI
+@testable import Pinwheel
+
+@MainActor
+final class PinwheelPreviewResolveTests: XCTestCase {
+    private var sections: [PinwheelSection] {
+        [
+            PinwheelSection("Components") {
+                PinwheelItem("Button") { SwiftUI.Text("") }
+                PinwheelItem("Label") { SwiftUI.Text("") }
+            },
+            PinwheelSection("Screens") {
+                PinwheelItem("Button") { SwiftUI.Text("") }
+            }
+        ]
+    }
+
+    func testResolvesABareItemID() {
+        XCTAssertEqual(PinwheelPreview.resolve(id: "label", in: sections)?.item.id, "label")
+    }
+
+    func testQualifiedIDDisambiguatesItemsSharingAnID() {
+        // "button" exists in both sections; the qualified form picks the section.
+        XCTAssertEqual(PinwheelPreview.resolve(id: "screens/button", in: sections)?.section.id, "screens")
+        XCTAssertEqual(PinwheelPreview.resolve(id: "components/button", in: sections)?.section.id, "components")
+    }
+
+    func testUnknownIDResolvesToNil() {
+        XCTAssertNil(PinwheelPreview.resolve(id: "nope", in: sections))
+        XCTAssertNil(PinwheelPreview.resolve(id: "components/nope", in: sections))
+    }
+
+    func testWhitespaceIsTrimmed() {
+        XCTAssertEqual(PinwheelPreview.resolve(id: "  label  ", in: sections)?.item.id, "label")
+    }
+}

--- a/Pinwheel/Tests/PinwheelTests/PinwheelTweakTests.swift
+++ b/Pinwheel/Tests/PinwheelTests/PinwheelTweakTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SwiftUI
+@testable import Pinwheel
+
+@MainActor
+final class PinwheelTweakTests: XCTestCase {
+    func testActionTweakRunsItsClosure() {
+        var ran = false
+        PinwheelTweak("Option", action: { ran = true }).applyAsPreviewVariant()
+        XCTAssertTrue(ran)
+    }
+
+    func testToggleTweakIsForcedOnAsPreviewVariant() {
+        var value = false
+        let binding = Binding(get: { value }, set: { value = $0 })
+        PinwheelTweak("Option", isOn: binding).applyAsPreviewVariant()
+        XCTAssertTrue(value, "applyAsPreviewVariant turns a toggle on, never off")
+    }
+
+    func testTextTweakBridgesToAnActionThatRuns() {
+        var ran = false
+        let bridged = PinwheelTweak(TextTweak(title: "Option", action: { ran = true }))
+        XCTAssertNotNil(bridged)
+        bridged?.applyAsPreviewVariant()
+        XCTAssertTrue(ran)
+    }
+
+    func testBoolTweakBridgesToAToggleThatForwardsToTheUIKitAction() {
+        var received: Bool?
+        let bridged = PinwheelTweak(BoolTweak(title: "Option", isOn: false, action: { received = $0 }))
+        guard case .toggle(let binding)? = bridged?.control else {
+            return XCTFail("a BoolTweak should bridge to a toggle control")
+        }
+        binding.wrappedValue = true
+        XCTAssertEqual(received, true, "flipping the bridged binding forwards to the UIKit tweak's action")
+    }
+
+    func testUnknownTweakKindBridgesToNil() {
+        struct CustomTweak: Tweak {
+            var title = "Custom"
+            var description: String?
+        }
+        XCTAssertNil(PinwheelTweak(CustomTweak()))
+    }
+}


### PR DESCRIPTION
Put the `DemoUITests` on trial: they were paying simulator prices to assert logic a unit catches in milliseconds. Pushed that logic into the library's `PinwheelTests` target (red-first), dropped the UI tests that only asserted it, and kept a small set of app-layer journeys — each documented in-code with its one-line reason.

The dropped UI tests are **demo** tests; the units test **library** types and live in the existing `PinwheelTests` target. No demo unit-test target needed.

**Added units (`PinwheelTests`), each proven red-first by breaking the source:**
- `PinwheelTweakTests` — action runs its closure; toggle forced on; `Tweakable`→`PinwheelTweak` bridge (Text→action, Bool→toggle forwarding to the UIKit action, unknown→nil).
- `PinwheelPreviewResolveTests` — `resolve(id:)` bare id / qualified `section/item` / unknown → nil / whitespace-trim (made `internal` for `@testable`).
- (plus the existing `PinwheelIdentityTests`.)

**Dropped 4 UI tests:** SwiftUI action, SwiftUI toggle, UIKit action-via-deep-link (logic → units), and the green-at-birth `StateView renders default empty` smoke test.

**Kept 7 UI tests**, each with a `// KEEP:` reason — sheet-reopen tweak stability, catalog nested presentation, UIKit bridge hosting the on-screen instance, the device-select layout-crash repro, and the SwiftUI + two UIKit-hosting retry journeys.

**Way forward** (noted in the suite headers): grow unit coverage by default; a new UI test is the exception, justified by an app-layer fact.

Verified: `PinwheelTests` 13/13 green; `DemoUITests` 11 → 7, all green.