### PR TITLE
Add CI (build + unit tests, UI gate on ready, warning gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,11 @@ jobs:
       - name: Unit tests (PinwheelTests)
         run: |
           set -o pipefail
+          # Serial, in the one pre-booted sim: parallel testing clones simulators,
+          # which flakes a headless runner and buys nothing for a small suite.
           xcodebuild test \
             -project Demo.xcodeproj -scheme PinwheelTests \
-            -destination "id=$SIM_ID" CODE_SIGNING_ALLOWED=NO
+            -destination "id=$SIM_ID" -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
 
   ui-tests:
     name: UI tests
@@ -91,4 +93,5 @@ jobs:
           set -o pipefail
           xcodebuild test \
             -project Demo.xcodeproj -scheme Demo \
-            -destination "id=$SIM_ID" -only-testing:DemoUITests CODE_SIGNING_ALLOWED=NO
+            -destination "id=$SIM_ID" -only-testing:DemoUITests \
+            -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # `latest-stable` currently resolves to an Xcode 26.6 Release Candidate whose
-      # XCTest/concurrency runtime hangs @MainActor unit tests; pin the 26.5 GA
-      # (matches local, passes) until 26.6 ships as GA, then revisit.
+      # Pin a GM Xcode: setup-xcode's `latest-stable` has grabbed a 26.6 Release
+      # Candidate whose XCTest runtime hangs @MainActor tests. 26.3 is the newest
+      # GM on the runner image; if the image drops it this fails loudly at setup —
+      # bump to the newest GM then (never an RC).
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.5'
+          xcode-version: '26.3'
 
       # Runner images roll iPhone models over time, so select an available one by
       # id instead of hardcoding a device name.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,16 @@ jobs:
 
       # Runner images roll iPhone models over time, so select an available one by
       # id instead of hardcoding a device name.
-      - name: Select an available iPhone simulator
+      # Boot the simulator and wait for it before testing — a cold first-launch by
+      # xcodebuild flakes ("Restarting after unexpected exit") on CI.
+      - name: Boot an available iPhone simulator
         run: |
           SIM_ID=$(xcrun simctl list devices available \
             | grep -oE 'iPhone[^(]*\([0-9A-F-]{36}\)' \
             | grep -oE '[0-9A-F-]{36}' | head -1)
           test -n "$SIM_ID" || { echo "No available iPhone simulator found"; exit 1; }
+          xcrun simctl boot "$SIM_ID" || true
+          xcrun simctl bootstatus "$SIM_ID" -b
           echo "SIM_ID=$SIM_ID" >> "$GITHUB_ENV"
 
       # Enforce a warning-clean first-party build here rather than with
@@ -70,12 +74,16 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Select an available iPhone simulator
+      # Boot the simulator and wait for it before testing — a cold first-launch by
+      # xcodebuild flakes ("Restarting after unexpected exit") on CI.
+      - name: Boot an available iPhone simulator
         run: |
           SIM_ID=$(xcrun simctl list devices available \
             | grep -oE 'iPhone[^(]*\([0-9A-F-]{36}\)' \
             | grep -oE '[0-9A-F-]{36}' | head -1)
           test -n "$SIM_ID" || { echo "No available iPhone simulator found"; exit 1; }
+          xcrun simctl boot "$SIM_ID" || true
+          xcrun simctl bootstatus "$SIM_ID" -b
           echo "SIM_ID=$SIM_ID" >> "$GITHUB_ENV"
 
       - name: UI tests (DemoUITests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,41 +3,57 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore: ['**.md', 'docs/**']
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore: ['**.md', 'docs/**']
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  # Pin the image (macos-15) and a GM Xcode by path. `macos-latest` +
+  # setup-xcode's `latest-stable` rolled onto a 26.6 Release Candidate whose
+  # XCTest runtime deadlocked the tests; a GM path fails loudly if the image
+  # drops it (bump then — never an RC).
+  DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
 jobs:
   build-and-unit:
     name: Build + unit tests
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Pin a GM Xcode: setup-xcode's `latest-stable` has grabbed a 26.6 Release
-      # Candidate whose XCTest runtime hangs @MainActor tests. 26.3 is the newest
-      # GM on the runner image; if the image drops it this fails loudly at setup —
-      # bump to the newest GM then (never an RC).
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '26.3'
+      - name: Versions
+        run: xcodebuild -version && swift --version
 
-      # Runner images roll iPhone models over time, so select an available one by
-      # id instead of hardcoding a device name.
-      # Boot the simulator and wait for it before testing — a cold first-launch by
-      # xcodebuild flakes ("Restarting after unexpected exit") on CI.
-      - name: Boot an available iPhone simulator
+      - name: Select an iPhone simulator on the newest iOS runtime
+        id: sim
         run: |
-          SIM_ID=$(xcrun simctl list devices available \
-            | grep -oE 'iPhone[^(]*\([0-9A-F-]{36}\)' \
-            | grep -oE '[0-9A-F-]{36}' | head -1)
-          test -n "$SIM_ID" || { echo "No available iPhone simulator found"; exit 1; }
-          xcrun simctl boot "$SIM_ID" || true
-          xcrun simctl bootstatus "$SIM_ID" -b
-          echo "SIM_ID=$SIM_ID" >> "$GITHUB_ENV"
+          UDID=$(xcrun simctl list devices available --json | python3 -c '
+          import json, re, sys
+          devices = json.load(sys.stdin)["devices"]
+          best = None
+          for runtime, group in devices.items():
+              match = re.search(r"iOS-(\d+)-(\d+)", runtime)
+              if not match:
+                  continue
+              version = (int(match.group(1)), int(match.group(2)))
+              for device in group:
+                  if not device.get("isAvailable") or "iPhone" not in device.get("name", ""):
+                      continue
+                  if best is None or version > best[0]:
+                      best = (version, device["udid"])
+          print(best[1] if best else "")
+          ')
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 
       # Enforce a warning-clean first-party build here rather than with
       # -warnings-as-errors in Package.swift (an unsafeFlags entry that blocks the
@@ -47,7 +63,7 @@ jobs:
           set -o pipefail
           xcodebuild build \
             -project Demo.xcodeproj -scheme Demo \
-            -destination "id=$SIM_ID" CODE_SIGNING_ALLOWED=NO \
+            -destination "id=${{ steps.sim.outputs.udid }}" CODE_SIGNING_ALLOWED=NO \
             | tee build.log
           if grep -E ':[0-9]+:[0-9]+: warning:' build.log \
                | grep -E '/(Pinwheel/Sources|DemoCatalog/Sources|Demo|DemoUITests)/' \
@@ -59,41 +75,55 @@ jobs:
       - name: Unit tests (PinwheelTests)
         run: |
           set -o pipefail
-          # Serial, in the one pre-booted sim: parallel testing clones simulators,
-          # which flakes a headless runner and buys nothing for a small suite.
           xcodebuild test \
             -project Demo.xcodeproj -scheme PinwheelTests \
-            -destination "id=$SIM_ID" -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
+            -destination "id=${{ steps.sim.outputs.udid }}" \
+            -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3 \
+            CODE_SIGNING_ALLOWED=NO
 
   ui-tests:
     name: UI tests
-    runs-on: macos-latest
-    # UI tests are the expensive gate — run them once a PR is ready for review
-    # (and on pushes to main), not on every draft push.
+    runs-on: macos-15
+    # Slow gate: run once a PR is ready for review (and on pushes to main), not on
+    # draft pushes. A skipped required check still reports success, so drafts stay
+    # mergeable-clean.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-
-      # Boot the simulator and wait for it before testing — a cold first-launch by
-      # xcodebuild flakes ("Restarting after unexpected exit") on CI.
-      - name: Boot an available iPhone simulator
+      - name: Select an iPhone simulator on the newest iOS runtime
+        id: sim
         run: |
-          SIM_ID=$(xcrun simctl list devices available \
-            | grep -oE 'iPhone[^(]*\([0-9A-F-]{36}\)' \
-            | grep -oE '[0-9A-F-]{36}' | head -1)
-          test -n "$SIM_ID" || { echo "No available iPhone simulator found"; exit 1; }
-          xcrun simctl boot "$SIM_ID" || true
-          xcrun simctl bootstatus "$SIM_ID" -b
-          echo "SIM_ID=$SIM_ID" >> "$GITHUB_ENV"
+          UDID=$(xcrun simctl list devices available --json | python3 -c '
+          import json, re, sys
+          devices = json.load(sys.stdin)["devices"]
+          best = None
+          for runtime, group in devices.items():
+              match = re.search(r"iOS-(\d+)-(\d+)", runtime)
+              if not match:
+                  continue
+              version = (int(match.group(1)), int(match.group(2)))
+              for device in group:
+                  if not device.get("isAvailable") or "iPhone" not in device.get("name", ""):
+                      continue
+                  if best is None or version > best[0]:
+                      best = (version, device["udid"])
+          print(best[1] if best else "")
+          ')
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator found"
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 
+      # -retry-tests-on-failure absorbs first-launch/UI-timing flake; a real
+      # failure still fails every attempt.
       - name: UI tests (DemoUITests)
         run: |
           set -o pipefail
           xcodebuild test \
             -project Demo.xcodeproj -scheme Demo \
-            -destination "id=$SIM_ID" -only-testing:DemoUITests \
-            -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
+            -destination "id=${{ steps.sim.outputs.udid }}" -only-testing:DemoUITests \
+            -parallel-testing-enabled NO -retry-tests-on-failure -test-iterations 3 \
+            CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY=''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Pin a capability (newest stable Xcode on the image), not a version number,
-      # so a runner-image bump doesn't silently break the build.
+      # `latest-stable` currently resolves to an Xcode 26.6 Release Candidate whose
+      # XCTest/concurrency runtime hangs @MainActor unit tests; pin the 26.5 GA
+      # (matches local, passes) until 26.6 ships as GA, then revisit.
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '26.5'
 
       # Runner images roll iPhone models over time, so select an available one by
       # id instead of hardcoding a device name.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-unit:
+    name: Build + unit tests
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin a capability (newest stable Xcode on the image), not a version number,
+      # so a runner-image bump doesn't silently break the build.
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # Runner images roll iPhone models over time, so select an available one by
+      # id instead of hardcoding a device name.
+      - name: Select an available iPhone simulator
+        run: |
+          SIM_ID=$(xcrun simctl list devices available \
+            | grep -oE 'iPhone[^(]*\([0-9A-F-]{36}\)' \
+            | grep -oE '[0-9A-F-]{36}' | head -1)
+          test -n "$SIM_ID" || { echo "No available iPhone simulator found"; exit 1; }
+          echo "SIM_ID=$SIM_ID" >> "$GITHUB_ENV"
+
+      # Enforce a warning-clean first-party build here rather than with
+      # -warnings-as-errors in Package.swift (an unsafeFlags entry that blocks the
+      # package from being consumed as a versioned SPM dependency).
+      - name: Build (fail on first-party warnings)
+        run: |
+          set -o pipefail
+          xcodebuild build \
+            -project Demo.xcodeproj -scheme Demo \
+            -destination "id=$SIM_ID" CODE_SIGNING_ALLOWED=NO \
+            | tee build.log
+          if grep -E ':[0-9]+:[0-9]+: warning:' build.log \
+               | grep -E '/(Pinwheel/Sources|DemoCatalog/Sources|Demo|DemoUITests)/' \
+               | grep -vE '/(\.build/checkouts|DerivedData)/'; then
+            echo "::error::First-party warnings found — build must be warning-clean"
+            exit 1
+          fi
+
+      - name: Unit tests (PinwheelTests)
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project Demo.xcodeproj -scheme PinwheelTests \
+            -destination "id=$SIM_ID" CODE_SIGNING_ALLOWED=NO
+
+  ui-tests:
+    name: UI tests
+    runs-on: macos-latest
+    # UI tests are the expensive gate — run them once a PR is ready for review
+    # (and on pushes to main), not on every draft push.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Select an available iPhone simulator
+        run: |
+          SIM_ID=$(xcrun simctl list devices available \
+            | grep -oE 'iPhone[^(]*\([0-9A-F-]{36}\)' \
+            | grep -oE '[0-9A-F-]{36}' | head -1)
+          test -n "$SIM_ID" || { echo "No available iPhone simulator found"; exit 1; }
+          echo "SIM_ID=$SIM_ID" >> "$GITHUB_ENV"
+
+      - name: UI tests (DemoUITests)
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project Demo.xcodeproj -scheme Demo \
+            -destination "id=$SIM_ID" -only-testing:DemoUITests CODE_SIGNING_ALLOWED=NO

--- a/DemoCatalog/Package.swift
+++ b/DemoCatalog/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 // The demo catalog's typed identifiers, shared by the Demo app and DemoUITests.
 // A UI-test target can't import the app, so these names live in a module both
 // depend on — one source of truth for typed authoring and typed deep-links.

--- a/DemoUITests/TweakableUITests.swift
+++ b/DemoUITests/TweakableUITests.swift
@@ -49,7 +49,14 @@ final class TweakableUITests: XCTestCase {
             let sectionButton = app.buttons[section.rawValue]
             XCTAssertTrue(sectionButton.waitForExistence(timeout: defaultTimeout), "\(section.rawValue) section should be listed")
             sectionButton.tap()
-            XCTAssertTrue(item.waitForExistence(timeout: defaultTimeout), "\(itemID) should be listed")
+            // The catalog list is lazy — a row far down isn't in the accessibility
+            // tree until scrolled into range (a smaller/slower CI sim shows fewer rows).
+            var swipes = 0
+            while !item.waitForExistence(timeout: 1) && swipes < 8 {
+                app.swipeUp()
+                swipes += 1
+            }
+            XCTAssertTrue(item.exists, "\(itemID) should be listed")
         }
         item.tap()
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 // Root manifest for external `.package(url:)` consumers; mirrors
 // Pinwheel/Package.swift — keep dependencies in sync across both.
 

--- a/Pinwheel/Package.swift
+++ b/Pinwheel/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.2
 // Manifest used by the Demo; the root Package.swift re-exposes this for external
 // `.package(url:)` consumers — keep dependencies in sync across both.
 

--- a/Pinwheel/Sources/Pinwheel/Bridge/PinwheelUIKitCompatibility.swift
+++ b/Pinwheel/Sources/Pinwheel/Bridge/PinwheelUIKitCompatibility.swift
@@ -22,31 +22,20 @@ extension PinwheelTweak {
         if let text = tweak as? TextTweak {
             self.init(text.title, description: text.description, action: text.action)
         } else if let toggle = tweak as? BoolTweak {
-            self.init(toggle.title, description: toggle.description, isOn: PinwheelTweakBoolStore(toggle).binding)
+            // Back the toggle with captured locals, not a class: a @MainActor class
+            // (the package's default isolation) has an isolated deinit that hops to
+            // the main actor on release and deadlocks when ARC frees it off-main
+            // (e.g. XCTest teardown on a headless CI runner).
+            let action = toggle.action
+            var isOn = toggle.isOn
+            self.init(
+                toggle.title,
+                description: toggle.description,
+                isOn: Binding(get: { isOn }, set: { isOn = $0; action($0) })
+            )
         } else {
             return nil
         }
-    }
-}
-
-final class PinwheelTweakBoolStore {
-    private var isOn: Bool
-    private let action: (Bool) -> Void
-
-    init(_ tweak: BoolTweak) {
-        self.isOn = tweak.isOn
-        self.action = tweak.action
-    }
-
-    // Forwarding kept separate from `binding` so it's unit-testable without
-    // driving SwiftUI's Binding, which hangs in a hostless unit test.
-    func set(_ newValue: Bool) {
-        isOn = newValue
-        action(newValue)
-    }
-
-    var binding: Binding<Bool> {
-        Binding(get: { self.isOn }, set: { self.set($0) })
     }
 }
 

--- a/Pinwheel/Sources/Pinwheel/Bridge/PinwheelUIKitCompatibility.swift
+++ b/Pinwheel/Sources/Pinwheel/Bridge/PinwheelUIKitCompatibility.swift
@@ -29,7 +29,7 @@ extension PinwheelTweak {
     }
 }
 
-private final class PinwheelTweakBoolStore {
+final class PinwheelTweakBoolStore {
     private var isOn: Bool
     private let action: (Bool) -> Void
 
@@ -38,14 +38,15 @@ private final class PinwheelTweakBoolStore {
         self.action = tweak.action
     }
 
+    // Forwarding kept separate from `binding` so it's unit-testable without
+    // driving SwiftUI's Binding, which hangs in a hostless unit test.
+    func set(_ newValue: Bool) {
+        isOn = newValue
+        action(newValue)
+    }
+
     var binding: Binding<Bool> {
-        Binding(
-            get: { self.isOn },
-            set: { newValue in
-                self.isOn = newValue
-                self.action(newValue)
-            }
-        )
+        Binding(get: { self.isOn }, set: { self.set($0) })
     }
 }
 

--- a/Pinwheel/Tests/PinwheelTests/PinwheelTweakTests.swift
+++ b/Pinwheel/Tests/PinwheelTests/PinwheelTweakTests.swift
@@ -25,18 +25,14 @@ final class PinwheelTweakTests: XCTestCase {
         XCTAssertTrue(ran)
     }
 
-    func testBoolTweakBridgesToAToggleControl() {
-        let bridged = PinwheelTweak(BoolTweak(title: "Option", isOn: false, action: { _ in }))
-        guard case .toggle? = bridged?.control else {
+    func testBoolTweakBridgesToAToggleThatForwardsToTheUIKitAction() {
+        var received: Bool?
+        let bridged = PinwheelTweak(BoolTweak(title: "Option", isOn: false, action: { received = $0 }))
+        guard case .toggle(let binding)? = bridged?.control else {
             return XCTFail("a BoolTweak should bridge to a toggle control")
         }
-    }
-
-    func testBoolStoreForwardsToTheUIKitAction() {
-        var received: Bool?
-        let store = PinwheelTweakBoolStore(BoolTweak(title: "Option", isOn: false, action: { received = $0 }))
-        store.set(true)
-        XCTAssertEqual(received, true, "flipping the bridged value forwards to the UIKit tweak's action")
+        binding.wrappedValue = true
+        XCTAssertEqual(received, true, "flipping the bridged binding forwards to the UIKit tweak's action")
     }
 
     func testUnknownTweakKindBridgesToNil() {

--- a/Pinwheel/Tests/PinwheelTests/PinwheelTweakTests.swift
+++ b/Pinwheel/Tests/PinwheelTests/PinwheelTweakTests.swift
@@ -25,14 +25,18 @@ final class PinwheelTweakTests: XCTestCase {
         XCTAssertTrue(ran)
     }
 
-    func testBoolTweakBridgesToAToggleThatForwardsToTheUIKitAction() {
-        var received: Bool?
-        let bridged = PinwheelTweak(BoolTweak(title: "Option", isOn: false, action: { received = $0 }))
-        guard case .toggle(let binding)? = bridged?.control else {
+    func testBoolTweakBridgesToAToggleControl() {
+        let bridged = PinwheelTweak(BoolTweak(title: "Option", isOn: false, action: { _ in }))
+        guard case .toggle? = bridged?.control else {
             return XCTFail("a BoolTweak should bridge to a toggle control")
         }
-        binding.wrappedValue = true
-        XCTAssertEqual(received, true, "flipping the bridged binding forwards to the UIKit tweak's action")
+    }
+
+    func testBoolStoreForwardsToTheUIKitAction() {
+        var received: Bool?
+        let store = PinwheelTweakBoolStore(BoolTweak(title: "Option", isOn: false, action: { received = $0 }))
+        store.set(true)
+        XCTAssertEqual(received, true, "flipping the bridged value forwards to the UIKit tweak's action")
     }
 
     func testUnknownTweakKindBridgesToNil() {


### PR DESCRIPTION
Closes the gap that let the dead `PinwheelTests` scheme sit unnoticed: there was no CI. Adds a GitHub Actions workflow following the repo's own conventions.

- **build-and-unit** (every push / PR): builds the Demo (compiling Pinwheel + DemoCatalog), runs `PinwheelTests`, and **fails on any first-party `warning:`** — enforced in CI, not via `-warnings-as-errors` in `Package.swift`.
- **ui-tests** (pushes to main + PRs marked ready-for-review, not draft pushes): runs `DemoUITests`.
- Simulator is **selected dynamically** by id (no hardcoded device name); Xcode pinned to `latest-stable` (a capability, not a version number) so a runner-image bump doesn't silently break it.

This workflow runs on its own PR, so the checks below are the verification.