### PR TITLE
Restyle filter pills to match Torget: bordered/filled, no All chip

### DIFF
--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -256,10 +256,13 @@ private struct PinwheelIndexView: SwiftUI.View {
 
     private var filterBar: some SwiftUI.View {
         ScrollView(.horizontal, showsIndicators: false) {
+            // No "All" chip — no selection means all. Tapping the selected tag again
+            // clears it (back to all).
             HStack(spacing: .spacingS) {
-                pill(title: "All", isSelected: selectedTag == nil) { selectedTag = nil }
                 ForEach(sectionTags, id: \.self) { tag in
-                    pill(title: tag.rawValue, isSelected: selectedTag == tag) { selectedTag = tag }
+                    pill(title: tag.rawValue, isSelected: selectedTag == tag) {
+                        selectedTag = selectedTag == tag ? nil : tag
+                    }
                 }
             }
             .padding(.horizontal, .spacingM)
@@ -271,18 +274,21 @@ private struct PinwheelIndexView: SwiftUI.View {
     private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
-                .font(.footnote)
-                // Selected: solid fill in the bright accent (the `actionText` token —
-                // `actionBackground` is a dark, muted variant) with inverse-of-surface
-                // text (no dedicated on-accent token; primaryBackground reads on the
-                // accent in both light and dark). Unselected: a muted secondary fill.
+                .font(.subtitle)
+                // Selected: solid accent fill (the `actionText` token — `actionBackground`
+                // is a dark, muted variant), its border the same accent so none shows, and
+                // inverse-of-surface text for high contrast on the fill. Unselected: no
+                // fill, just a border.
                 .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
-                .padding(.horizontal, .spacingM)
+                .padding(.horizontal, .spacingL)
                 .padding(.vertical, .spacingS)
-                .background(
-                    isSelected ? AnyShapeStyle(.actionText) : AnyShapeStyle(.secondaryBackground),
-                    in: Capsule()
-                )
+                .background {
+                    if isSelected {
+                        Capsule().fill(.actionText)
+                    } else {
+                        Capsule().strokeBorder(.secondaryText, lineWidth: 1)
+                    }
+                }
         }
         .buttonStyle(.plain)
     }

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -274,14 +274,14 @@ private struct PinwheelIndexView: SwiftUI.View {
     private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
-                .font(.subtitle)
+                .font(.footnote)
                 // Selected: solid accent fill (the `actionText` token — `actionBackground`
                 // is a dark, muted variant), its border the same accent so none shows, and
                 // inverse-of-surface text for high contrast on the fill. Unselected: no
                 // fill, just a border.
                 .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
-                .padding(.horizontal, .spacingL)
-                .padding(.vertical, .spacingS)
+                .padding(.horizontal, .spacingM)
+                .padding(.vertical, .spacingXS)
                 .background {
                     if isSelected {
                         Capsule().fill(.actionText)

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -274,7 +274,8 @@ private struct PinwheelIndexView: SwiftUI.View {
     private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
-                .font(.body)
+                // No explicit .font — inherits PinLabel's default (.body), the same
+                // as the list rows, so pill and row text stay one size by construction.
                 // Selected: solid accent fill (the `actionText` token — `actionBackground`
                 // is a dark, muted variant), its border the same accent so none shows, and
                 // inverse-of-surface text for high contrast on the fill. Unselected: no

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -256,8 +256,6 @@ private struct PinwheelIndexView: SwiftUI.View {
 
     private var filterBar: some SwiftUI.View {
         ScrollView(.horizontal, showsIndicators: false) {
-            // No "All" chip — no selection means all. Tapping the selected tag again
-            // clears it (back to all).
             HStack(spacing: .spacingS) {
                 ForEach(sectionTags, id: \.self) { tag in
                     pill(title: tag.rawValue, isSelected: selectedTag == tag) {
@@ -274,12 +272,6 @@ private struct PinwheelIndexView: SwiftUI.View {
     private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
-                // No explicit .font — inherits PinLabel's default (.body), the same
-                // as the list rows, so pill and row text stay one size by construction.
-                // Selected: solid accent fill (the `actionText` token — `actionBackground`
-                // is a dark, muted variant), its border the same accent so none shows, and
-                // inverse-of-surface text for high contrast on the fill. Unselected: no
-                // fill, just a border.
                 .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
                 .padding(.horizontal, .spacingM)
                 .padding(.vertical, .spacingS)

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -272,11 +272,15 @@ private struct PinwheelIndexView: SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
                 .font(.footnote)
-                .color(isSelected ? .action : .secondary)
-                .padding(.horizontal, .spacingS)
-                .padding(.vertical, .spacingXS)
+                // Selected: solid fill in the bright accent (the `actionText` token —
+                // `actionBackground` is a dark, muted variant) with inverse-of-surface
+                // text (no dedicated on-accent token; primaryBackground reads on the
+                // accent in both light and dark). Unselected: a muted secondary fill.
+                .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
+                .padding(.horizontal, .spacingM)
+                .padding(.vertical, .spacingS)
                 .background(
-                    isSelected ? AnyShapeStyle(.actionBackground.opacity(0.15)) : AnyShapeStyle(.secondaryBackground),
+                    isSelected ? AnyShapeStyle(.actionText) : AnyShapeStyle(.secondaryBackground),
                     in: Capsule()
                 )
         }

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -220,7 +220,7 @@ private struct PinwheelIndexView: SwiftUI.View {
                                 .listRowBackground(PinwheelTheme.Colors.primaryBackground)
                             }
                         } header: {
-                            PinLabel(group.letter).font(.footnote).color(.secondary)
+                            PinLabel(group.letter).font(.body).color(.secondary)
                                 .textCase(nil)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
@@ -265,8 +265,8 @@ private struct PinwheelIndexView: SwiftUI.View {
                     }
                 }
             }
-            .padding(.horizontal, .spacingM)
-            .padding(.vertical, .spacingS)
+            .padding(.horizontal, .spacingXM)
+            .padding(.vertical, .spacingM)
         }
         .background(.primaryBackground)
     }
@@ -274,14 +274,14 @@ private struct PinwheelIndexView: SwiftUI.View {
     private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
-                .font(.footnote)
+                .font(.body)
                 // Selected: solid accent fill (the `actionText` token — `actionBackground`
                 // is a dark, muted variant), its border the same accent so none shows, and
                 // inverse-of-surface text for high contrast on the fill. Unselected: no
                 // fill, just a border.
                 .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
                 .padding(.horizontal, .spacingM)
-                .padding(.vertical, .spacingXS)
+                .padding(.vertical, .spacingS)
                 .background {
                     if isSelected {
                         Capsule().fill(.actionText)


### PR DESCRIPTION
Matches the reference filter chips:
- **Unselected** — no fill, just a border; high-contrast text.
- **Selected** — solid accent fill (its border blends into the fill so none shows), inverse-of-surface text for high contrast.
- **Larger** — `.subtitle` text with roomier padding, closer to the reference's size.
- **No "All" chip** — no selection means all; tapping the selected tag again clears it (back to all).

Themed via the `actionText` accent (the bright accent; `actionBackground` is a dark muted variant) and `primaryBackground` text; the border uses `secondaryText`. No hardcoded colors — tracks the consumer's `Config` palette. Verified selected + unselected in light and dark on the simulator; `DemoUITests` 7/7 green.