### PR TITLE
Fade content under the filter pills on scroll

### DIFF
--- a/Demo/Examples/SwiftUI/TokensSwiftUIExamples.swift
+++ b/Demo/Examples/SwiftUI/TokensSwiftUIExamples.swift
@@ -14,7 +14,7 @@ struct PinFontExample: SwiftUI.View {
     var body: some SwiftUI.View {
         List(styles, id: \.0) { title, style in
             PinLabel(title).font(style)
-                .listRowBackground(PinwheelTheme.Colors.primaryBackground)
+                .listRowBackground(Color.primaryBackground)
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -188,6 +188,11 @@ private struct PinwheelIndexView: SwiftUI.View {
     let selectedItem: (PinwheelItem) -> Void
 
     @State private var selectedTag: PinTag?
+    @State private var scrolledDistance: CGFloat = 0
+
+    private var fadeOpacity: Double {
+        Double(min(1, max(0, scrolledDistance) / 24))
+    }
 
     var body: some SwiftUI.View {
         ScrollViewReader { proxy in
@@ -231,6 +236,11 @@ private struct PinwheelIndexView: SwiftUI.View {
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
                 .background(.primaryBackground)
+                .onScrollGeometryChange(for: CGFloat.self) { geometry in
+                    geometry.contentOffset.y + geometry.contentInsets.top
+                } action: { _, distance in
+                    scrolledDistance = distance
+                }
 
                 VStack(spacing: 2) {
                     ForEach(groupedItems, id: \.letter) { group in
@@ -249,6 +259,20 @@ private struct PinwheelIndexView: SwiftUI.View {
         .safeAreaInset(edge: .top, spacing: 0) {
             if sectionTags.count > 1 {
                 filterBar
+                    .overlay(alignment: .bottom) {
+                        LinearGradient(
+                            colors: [
+                                PinwheelTheme.Colors.primaryBackground,
+                                PinwheelTheme.Colors.primaryBackground.opacity(0)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 24)
+                        .offset(y: 24)
+                        .opacity(fadeOpacity)
+                        .allowsHitTesting(false)
+                    }
             }
         }
         .onChange(of: section?.id) { selectedTag = nil }
@@ -263,8 +287,8 @@ private struct PinwheelIndexView: SwiftUI.View {
                     }
                 }
             }
-            .padding(.horizontal, .spacingXM)
-            .padding(.vertical, .spacingM)
+            .padding(.horizontal, .spacingS)
+            .padding(.vertical, .spacingS)
         }
         .background(.primaryBackground)
     }

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -190,8 +190,12 @@ private struct PinwheelIndexView: SwiftUI.View {
     @State private var selectedTag: PinTag?
     @State private var scrolledDistance: CGFloat = 0
 
+    // Height matches the offset so the scrim sits flush below the pill bar.
+    private static let scrimHeight: CGFloat = 40
+    private static let scrimRampDistance: CGFloat = 24
+
     private var fadeOpacity: Double {
-        Double(min(1, max(0, scrolledDistance) / 24))
+        Double(min(1, max(0, scrolledDistance) / Self.scrimRampDistance))
     }
 
     var body: some SwiftUI.View {
@@ -268,8 +272,8 @@ private struct PinwheelIndexView: SwiftUI.View {
                             startPoint: .top,
                             endPoint: .bottom
                         )
-                        .frame(height: 24)
-                        .offset(y: 24)
+                        .frame(height: Self.scrimHeight)
+                        .offset(y: Self.scrimHeight)
                         .opacity(fadeOpacity)
                         .allowsHitTesting(false)
                     }

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -100,7 +100,7 @@ struct PinwheelCatalogView: SwiftUI.View {
                 .buttonStyle(.plain)
                 .foregroundStyle(isSelected ? .actionText : .primaryText)
                 .listRowSeparatorTint(.secondaryBackground)
-                .listRowBackground(PinwheelTheme.Colors.primaryBackground)
+                .listRowBackground(Color.primaryBackground)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
@@ -218,7 +218,7 @@ private struct PinwheelIndexView: SwiftUI.View {
                                 .buttonStyle(.plain)
                                 .accessibilityIdentifier(item.id)
                                 .listRowSeparator(.hidden)
-                                .listRowBackground(PinwheelTheme.Colors.primaryBackground)
+                                .listRowBackground(Color.primaryBackground)
                             }
                         } header: {
                             PinLabel(group.letter).font(.body).color(.secondary)

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelCatalogView.swift
@@ -190,14 +190,6 @@ private struct PinwheelIndexView: SwiftUI.View {
     @State private var selectedTag: PinTag?
     @State private var scrolledDistance: CGFloat = 0
 
-    // Height matches the offset so the scrim sits flush below the pill bar.
-    private static let scrimHeight: CGFloat = 40
-    private static let scrimRampDistance: CGFloat = 24
-
-    private var fadeOpacity: Double {
-        Double(min(1, max(0, scrolledDistance) / Self.scrimRampDistance))
-    }
-
     var body: some SwiftUI.View {
         ScrollViewReader { proxy in
             ZStack(alignment: .trailing) {
@@ -262,56 +254,14 @@ private struct PinwheelIndexView: SwiftUI.View {
         }
         .safeAreaInset(edge: .top, spacing: 0) {
             if sectionTags.count > 1 {
-                filterBar
-                    .overlay(alignment: .bottom) {
-                        LinearGradient(
-                            colors: [
-                                PinwheelTheme.Colors.primaryBackground,
-                                PinwheelTheme.Colors.primaryBackground.opacity(0)
-                            ],
-                            startPoint: .top,
-                            endPoint: .bottom
-                        )
-                        .frame(height: Self.scrimHeight)
-                        .offset(y: Self.scrimHeight)
-                        .opacity(fadeOpacity)
-                        .allowsHitTesting(false)
-                    }
+                PinwheelFilterBar(
+                    tags: sectionTags,
+                    selectedTag: $selectedTag,
+                    scrolledDistance: scrolledDistance
+                )
             }
         }
         .onChange(of: section?.id) { selectedTag = nil }
-    }
-
-    private var filterBar: some SwiftUI.View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: .spacingS) {
-                ForEach(sectionTags, id: \.self) { tag in
-                    pill(title: tag.rawValue, isSelected: selectedTag == tag) {
-                        selectedTag = selectedTag == tag ? nil : tag
-                    }
-                }
-            }
-            .padding(.horizontal, .spacingS)
-            .padding(.vertical, .spacingS)
-        }
-        .background(.primaryBackground)
-    }
-
-    private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
-        SwiftUI.Button(action: action) {
-            PinLabel(title)
-                .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
-                .padding(.horizontal, .spacingM)
-                .padding(.vertical, .spacingS)
-                .background {
-                    if isSelected {
-                        Capsule().fill(.actionText)
-                    } else {
-                        Capsule().strokeBorder(.secondaryText, lineWidth: 1)
-                    }
-                }
-        }
-        .buttonStyle(.plain)
     }
 
     private var sectionTags: [PinTag] {

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFilterBar.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFilterBar.swift
@@ -17,10 +17,7 @@ struct PinwheelFilterBar: SwiftUI.View {
         pills
             .overlay(alignment: .bottom) {
                 LinearGradient(
-                    colors: [
-                        PinwheelTheme.Colors.primaryBackground,
-                        PinwheelTheme.Colors.primaryBackground.opacity(0)
-                    ],
+                    colors: [.primaryBackground, .primaryBackground.opacity(0)],
                     startPoint: .top,
                     endPoint: .bottom
                 )
@@ -49,7 +46,7 @@ struct PinwheelFilterBar: SwiftUI.View {
     private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
-                .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .action)
+                .color(isSelected ? .custom(.primaryBackground) : .action)
                 .padding(.horizontal, .spacingM)
                 .padding(.vertical, .spacingS)
                 .background {

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFilterBar.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFilterBar.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct PinwheelFilterBar: SwiftUI.View {
+    let tags: [PinTag]
+    @Binding var selectedTag: PinTag?
+    let scrolledDistance: CGFloat
+
+    // Height matches the offset so the scrim sits flush below the pill bar.
+    private static let scrimHeight: CGFloat = 40
+    private static let scrimRampDistance: CGFloat = 24
+
+    private var fadeOpacity: Double {
+        Double(min(1, max(0, scrolledDistance) / Self.scrimRampDistance))
+    }
+
+    var body: some SwiftUI.View {
+        pills
+            .overlay(alignment: .bottom) {
+                LinearGradient(
+                    colors: [
+                        PinwheelTheme.Colors.primaryBackground,
+                        PinwheelTheme.Colors.primaryBackground.opacity(0)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: Self.scrimHeight)
+                .offset(y: Self.scrimHeight)
+                .opacity(fadeOpacity)
+                .allowsHitTesting(false)
+            }
+    }
+
+    private var pills: some SwiftUI.View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: .spacingS) {
+                ForEach(tags, id: \.self) { tag in
+                    pill(title: tag.rawValue, isSelected: selectedTag == tag) {
+                        selectedTag = selectedTag == tag ? nil : tag
+                    }
+                }
+            }
+            .padding(.horizontal, .spacingS)
+            .padding(.vertical, .spacingS)
+        }
+        .background(.primaryBackground)
+    }
+
+    private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
+        SwiftUI.Button(action: action) {
+            PinLabel(title)
+                .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
+                .padding(.horizontal, .spacingM)
+                .padding(.vertical, .spacingS)
+                .background {
+                    if isSelected {
+                        Capsule().fill(.actionText)
+                    } else {
+                        Capsule().strokeBorder(.secondaryText, lineWidth: 1)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFilterBar.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelFilterBar.swift
@@ -49,14 +49,14 @@ struct PinwheelFilterBar: SwiftUI.View {
     private func pill(title: String, isSelected: Bool, action: @escaping () -> Void) -> some SwiftUI.View {
         SwiftUI.Button(action: action) {
             PinLabel(title)
-                .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .primary)
+                .color(isSelected ? .custom(PinwheelTheme.Colors.primaryBackground) : .action)
                 .padding(.horizontal, .spacingM)
                 .padding(.vertical, .spacingS)
                 .background {
                     if isSelected {
                         Capsule().fill(.actionText)
                     } else {
-                        Capsule().strokeBorder(.secondaryText, lineWidth: 1)
+                        Capsule().strokeBorder(.actionText, lineWidth: 1)
                     }
                 }
         }

--- a/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPlayground.swift
+++ b/Pinwheel/Sources/Pinwheel/Catalog/PinwheelPlayground.swift
@@ -210,7 +210,7 @@ private struct PinwheelSettingsView: SwiftUI.View {
         List {
             ForEach(tweaks) { tweak in
                 tweakRow(tweak)
-                    .listRowBackground(PinwheelTheme.Colors.primaryBackground)
+                    .listRowBackground(Color.primaryBackground)
             }
         }
         .listStyle(.plain)
@@ -275,7 +275,7 @@ private struct PinwheelDeviceList: SwiftUI.View {
                 }
                 .buttonStyle(.plain)
                 .disabled(!device.isEnabled)
-                .listRowBackground(PinwheelTheme.Colors.primaryBackground)
+                .listRowBackground(Color.primaryBackground)
             }
         }
         .listStyle(.plain)

--- a/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinList.swift
+++ b/Pinwheel/Sources/Pinwheel/Components/SwiftUI/PinList.swift
@@ -16,7 +16,7 @@ public struct PinList: SwiftUI.View {
         case .loaded:
             // No per-row id to key on; positional identity is stable because rows are a fixed value array per render.
             List(Array(rows.enumerated()), id: \.offset) { _, row in
-                row.listRowBackground(PinwheelTheme.Colors.primaryBackground)
+                row.listRowBackground(Color.primaryBackground)
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)

--- a/Pinwheel/Sources/Pinwheel/Tokens/PinwheelTheme.swift
+++ b/Pinwheel/Sources/Pinwheel/Tokens/PinwheelTheme.swift
@@ -49,8 +49,9 @@ public enum PinwheelTheme {
     }
 }
 
-/// `.red`-style shorthand for the themed colors. Can't reach `.listRowBackground(_:)`,
-/// whose parameter is a generic `View`, not a `ShapeStyle`.
+/// `.red`-style shorthand for the themed colors. The leading-dot form needs a
+/// `ShapeStyle`/`Color` context to resolve; at `.listRowBackground(_:)` (a generic
+/// `View` parameter) spell the type: `Color.primaryBackground`.
 public extension ShapeStyle where Self == Color {
     static var primaryText: Color { PinwheelTheme.Colors.primaryText }
     static var secondaryText: Color { PinwheelTheme.Colors.secondaryText }


### PR DESCRIPTION
The catalog list scrolls under the pinned filter pills. At rest there's nothing to hide, but once you scroll, rows slide up behind the pills with a hard edge.

Now a scrim sits in the 24pt just below the pills — the surface color fading to transparent. It's invisible at the top (opacity ramps from 0) and eases in as you scroll, so content dissolves softly under the bar instead of cutting off. It adapts to light/dark and the theme like every other surface.